### PR TITLE
Add name and code to initializer

### DIFF
--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -30,13 +30,9 @@ module Stoplight
       data_store.failure_threshold(name) || DEFAULT_FAILURE_THRESHOLD
     end
 
-    def initialize(name)
+    def initialize(name, &code)
       @name = name
-    end
-
-    def with_code(&code)
       @code = code
-      self
     end
 
     def with_allowed_errors(errors)

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -4,8 +4,9 @@ require 'spec_helper'
 
 describe Stoplight::Light do
   let(:name) { SecureRandom.hex }
+  let(:code) { proc {} }
 
-  subject(:light) { described_class.new(name) }
+  subject(:light) { described_class.new(name, &code) }
 
   describe '.data_store' do
     let(:klass) { Class.new(described_class) }
@@ -29,20 +30,6 @@ describe Stoplight::Light do
     end
   end
 
-  describe '#with_code' do
-    let(:code) { proc {} }
-
-    subject(:result) { light.with_code(&code) }
-
-    it 'returns self' do
-      expect(result).to equal(light)
-    end
-
-    it 'assigns @code' do
-      expect(result.instance_variable_get(:@code)).to eql(code)
-    end
-  end
-
   describe '#with_fallback' do
     let(:fallback) { proc {} }
 
@@ -60,20 +47,8 @@ describe Stoplight::Light do
   describe '#code' do
     subject(:result) { light.code }
 
-    context 'without code' do
-      it 'raises an error' do
-        expect { result }.to raise_error(Stoplight::Error::NoCode)
-      end
-    end
-
-    context 'with code' do
-      let(:code) { proc {} }
-
-      before { light.with_code(&code) }
-
-      it 'returns the code' do
-        expect(result).to eql(code)
-      end
+    it 'returns the code' do
+      expect(result).to eql(code)
     end
   end
 


### PR DESCRIPTION
Since both the name and code are required, it makes sense to put them in the initializer.

``` rb
# before
Stoplight::Light.new.with_name('example').with_code { puts 'code' }

# after
Stoplight::Light.new('example') { puts 'code' }
```
