### PR TITLE
Officially support Ruby >= 1.9.3, JRuby, and Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ notifications:
     rooms:
       secure: DXcSlmn6T95WXrsAyqX58Em0A6Fx6lwWiqKBy7zIKVQjWeu2/ZB57V6dVKiewOUJssc8DU5NGvj2WAtAIbeShY0VSe70bs0abCrAFqVzB0ubmjXlaQ/FYp1Cqs21I8hOaiG8H0G0LUdp29Z/34m/APcVVYV9jbnjzjqH/ClqPjU=
     template: '%{repository}<a href="%{build_url}">#%{build_number}</a> [%{branch} <a href="%{compare_url}">%{commit}</a>] %{message}'
+rvm:
+- 1.9
+- 2.0
+- 2.1
+- jruby
+- rbx-2


### PR DESCRIPTION
Fixes #23.

I didn't actually test this locally. The Rubinius build will probably fail.
