### PR TITLE
Fall back to in-memory data store

### DIFF
--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -34,6 +34,7 @@ module Stoplight
       end
 
       def sync(name)
+        fail ::Redis::TimeoutError
         threshold = @redis.hget(DataStore.thresholds_key, name)
         threshold = normalize_threshold(threshold)
         @redis.hset(DataStore.thresholds_key, name, threshold)

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -24,7 +24,7 @@ module Stoplight
     # @see #fallback
     # @see #green?
     def run
-      Stoplight.data_store.sync(name)
+      sync
 
       case color
       when DataStore::COLOR_GREEN
@@ -141,6 +141,13 @@ module Stoplight
 
     def notify(message)
       Stoplight.notifiers.each { |notifier| notifier.notify(message) }
+    end
+
+    def sync
+      Stoplight.data_store.sync(name)
+    rescue => error
+      warn error
+      Stoplight.data_store = DataStore::Memory.new
     end
   end
 end


### PR DESCRIPTION
:warning: Do not merge!

This is a stab at fixing #6.

Before:

``` irb
>> Stoplight.data_store = Stoplight::DataStore::Redis.new(Redis.new)
=> #<Stoplight::DataStore::Redis:...>
>> light = Stoplight::Light.new('light') { true }
=> #<Stoplight::Light:...>
>> light.run
Redis::TimeoutError: Redis::TimeoutError
```

After:

``` irb
>> Stoplight.data_store = Stoplight::DataStore::Redis.new(Redis.new)
=> #<Stoplight::DataStore::Redis:...>
>> light = Stoplight::Light.new('light') { true }
=> #<Stoplight::Light:...>
>> light.run
Redis::TimeoutError
=> true
```

This is an extremely rough cut of what it might look like to fall back to a different data store. There are a couple problems here:
- I'm catching all errors in `Light#sync` when I probably just want to catch `Redis::TimeoutError`.
- `DataStore#sync` should probably be responsible for wrapping errors in some other class.
- If the in-memory data store itself fails for some reason, this basically does nothing. 
- If something other than `#sync` fails, this doesn't do anything. 
