### PR TITLE
Create a helper function for creating stoplights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This project uses [Semantic Versioning][1].
 
+- Created a convenience function for creating stoplights.
+
 ## v0.5.1 (2014-11-19)
 
 - Fixed a logic bug that incorrectly determined red lights to be yellow.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Stoplight::Light.default_notifiers += [Stoplight::Notifier::HipChat.new(...)]
 To get started, create a stoplight:
 
 ``` rb
-light = Stoplight::Light.new('example-1') { 22.0 / 7 }
+light = Stoplight('example-1') { 22.0 / 7 }
 # => #<Stoplight::Light:...>
 ```
 
@@ -156,7 +156,7 @@ you're using a stoplight. That's not very interesting though. Let's
 create a failing stoplight:
 
 ``` rb
-light = Stoplight::Light.new('example-2') { 1 / 0 }
+light = Stoplight('example-2') { 1 / 0 }
 # => #<Stoplight::Light:...>
 ```
 
@@ -188,7 +188,7 @@ state. Usually these are handled elsewhere in your stack and don't
 represent real failures. A good example is `ActiveRecord::RecordNotFound`.
 
 ``` rb
-light = Stoplight::Light.new('example-3') { User.find(123) }
+light = Stoplight('example-3') { User.find(123) }
   .with_allowed_errors([ActiveRecord::RecordNotFound])
 # => #<Stoplight::Light:...>
 light.run
@@ -209,7 +209,7 @@ error. You can provide a fallback that will be called in both of
 these cases. It will be passed the error if the light was green.
 
 ``` rb
-light = Stoplight::Light.new('example-4') { 1 / 0 }
+light = Stoplight('example-4') { 1 / 0 }
   .with_fallback { |e| p e; 'default' }
 # => #<Stoplight::Light:..>
 light.run
@@ -234,7 +234,7 @@ than others. You can configure this by setting a custom threshold
 in seconds.
 
 ``` rb
-light = Stoplight::Light.new('example-5') { fail }
+light = Stoplight('example-5') { fail }
   .with_threshold(1)
 # => #<Stoplight::Light:...>
 light.run
@@ -251,7 +251,7 @@ amount of time.  A light in the red state for longer than the timeout
 will transition to the yellow state. This timeout is customizable.
 
 ``` rb
-light = Stoplight::Light.new('example-6') { fail }
+light = Stoplight('example-6') { fail }
   .with_timeout(1)
 # => #<Stoplight::Light:...>
 light.run
@@ -281,7 +281,7 @@ class ApplicationController < ActionController::Base
   around_action :stoplight
   private
   def stoplight(&block)
-    Stoplight::Light.new("#{params[:controller]}##{params[:action]}", &block)
+    Stoplight("#{params[:controller]}##{params[:action]}", &block)
       .with_allowed_errors([ActiveRecord::RecordNotFound])
       .with_fallback do |error|
         Rails.logger.error(error)
@@ -301,7 +301,7 @@ want to override the default behavior. You can lock a light in
 either the green or red state using `set_state`.
 
 ``` rb
-light = Stoplight::Light.new('example-7') { true }
+light = Stoplight('example-7') { true }
 # => #<Stoplight::Light:..>
 light.run
 # => true

--- a/bench/memory_bench.rb
+++ b/bench/memory_bench.rb
@@ -6,8 +6,8 @@ require 'stoplight'
 Benchmark.ips do |b|
   b.report('creating lambda')    { -> {} }
   b.report('calling lambda')     { -> {}.call }
-  b.report('creating stoplight') { Stoplight::Light.new('') {} }
-  b.report('calling stoplight')  { Stoplight::Light.new('') {}.run }
+  b.report('creating stoplight') { Stoplight('') {} }
+  b.report('calling stoplight')  { Stoplight('') {}.run }
 
   b.compare!
 end

--- a/bench/redis_bench.rb
+++ b/bench/redis_bench.rb
@@ -11,8 +11,8 @@ Stoplight::Light.default_data_store = data_store
 Benchmark.ips do |b|
   b.report('creating lambda')    { -> {} }
   b.report('calling lambda')     { -> {}.call }
-  b.report('creating stoplight') { Stoplight::Light.new('') {} }
-  b.report('calling stoplight')  { Stoplight::Light.new('') {}.run }
+  b.report('creating stoplight') { Stoplight('') {} }
+  b.report('calling stoplight')  { Stoplight('') {}.run }
 
   b.compare!
 end

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -24,3 +24,7 @@ require 'stoplight/default'
 
 require 'stoplight/light/runnable'
 require 'stoplight/light'
+
+def Stoplight(name, &code) # rubocop:disable Style/MethodName
+  Stoplight::Light.new(name, &code)
+end

--- a/spec/stoplight_spec.rb
+++ b/spec/stoplight_spec.rb
@@ -7,3 +7,15 @@ describe Stoplight do
     expect(described_class).to be_a(Module)
   end
 end
+
+describe 'Stoplight' do
+  subject(:light) { Stoplight(name, &code) }
+  let(:name) { ('a'..'z').to_a.shuffle.join }
+  let(:code) { -> {} }
+
+  it 'creates a stoplight' do
+    expect(light).to be_a(Stoplight::Light)
+    expect(light.name).to eql(name)
+    expect(light.code).to eql(code)
+  end
+end


### PR DESCRIPTION
This pull request creates a `Stoplight` helper function that acts as an alias for `Stoplight::Light.new`. This is purely for convenience and doesn't add any new functionality.

``` rb
# Before
Stoplight::Light.new('example') { nil }.run
# After
Stoplight('example') { nil }.run
```

I got the idea from [circuit_b](https://github.com/alg/circuit_b/tree/1.1#usage). I'm not convinced that `Stoplight` is the right name for this function. Some other options include:

- `stoplight`: This seems like it would often conflict with a local variable. 
- `Stoplight.light`: This has the benefit of existing within the stoplight module, but it's still a little verbose. 