### PR TITLE
Add a Honeybadger notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Stoplight uses [Semantic Versioning][1].
 
+- Added a Honeybadger notifier.
+
 ## v1.1.1 (2015-07-16)
 
 - Introduced a generic notifier to reduce duplication between the IO and Slack

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Check out [stoplight-admin][] for controlling your stoplights.
     - [Redis](#redis)
   - [Notifiers](#notifiers)
     - [HipChat](#hipchat)
+    - [Honeybadger](#honeybadger)
     - [Slack](#slack)
   - [Rails](#rails-1)
 - [Advanced usage](#advanced-usage)
@@ -294,6 +295,20 @@ Stoplight::Light.default_notifiers += [notifier]
 # => [#<Stoplight::Notifier::IO:...>, #<Stoplight::Notifier::HipChat:...>]
 ```
 
+#### Honeybadger
+
+Make sure you have [the Honeybadger gem][] (`~> 2.1`) installed before
+configuring Stoplight.
+
+``` rb
+require 'honeybadger'
+# => true
+notifier = Stoplight::Notifier::Honeybadger.new('api key')
+# => #<Stoplight::Notifier::Honeybadger:...>
+Stoplight::Light.default_notifiers += [notifier]
+# => [#<Stoplight::Notifier::IO:...>, #<Stoplight::Notifier::Honeybadger:...>]
+```
+
 #### Slack
 
 Make sure you have [the Slack gem][] (`~> 1.2`) installed before configuring
@@ -405,6 +420,7 @@ Stoplight is licensed under [the MIT License][].
 [the timeout section]: #custom-timeout
 [the redis gem]: https://rubygems.org/gems/redis
 [the hipchat gem]: https://rubygems.org/gems/hipchat
+[the honeybadger gem]: https://rubygems.org/gems/honeybadger
 [the slack gem]: https://rubygems.org/gems/slack-notifier
 [@camdez]: https://github.com/camdez
 [@tfausak]: https://github.com/tfausak

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -19,6 +19,7 @@ require 'stoplight/notifier'
 require 'stoplight/notifier/base'
 require 'stoplight/notifier/generic'
 require 'stoplight/notifier/hip_chat'
+require 'stoplight/notifier/honeybadger'
 require 'stoplight/notifier/io'
 require 'stoplight/notifier/slack'
 

--- a/lib/stoplight/notifier/honeybadger.rb
+++ b/lib/stoplight/notifier/honeybadger.rb
@@ -1,0 +1,43 @@
+# coding: utf-8
+
+module Stoplight
+  module Notifier
+    # @see Base
+    class Honeybadger < Base
+      DEFAULT_OPTIONS = {
+        parameters: {},
+        session: {},
+        context: {}
+      }.freeze
+
+      # @return [String]
+      attr_reader :api_key
+      # @return [Proc]
+      attr_reader :formatter
+      # @return [Hash{Symbol => Object}]
+      attr_reader :options
+
+      # @param api_key [String]
+      # @param formatter [Proc, nil]
+      # @param options [Hash{Symbol => Object}]
+      # @option options [Hash] :parameters
+      # @option options [Hash] :session
+      # @option options [Hash] :context
+      def initialize(api_key, formatter = nil, options = {})
+        @api_key = api_key
+        @formatter = formatter || Default::FORMATTER
+        @options = DEFAULT_OPTIONS.merge(options)
+      end
+
+      def notify(light, from_color, to_color, error)
+        message = formatter.call(light, from_color, to_color, error)
+        h = options.merge(
+          api_key: api_key,
+          error_message: message,
+          backtrace: (error.backtrace if error))
+        ::Honeybadger.notify(h)
+        message
+      end
+    end
+  end
+end

--- a/spec/stoplight/notifier/honeybadger_spec.rb
+++ b/spec/stoplight/notifier/honeybadger_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'honeybadger'
+
+RSpec.describe Stoplight::Notifier::Honeybadger do
+  it 'is a class' do
+    expect(described_class).to be_a(Class)
+  end
+
+  it 'is a subclass of Base' do
+    expect(described_class).to be < Stoplight::Notifier::Base
+  end
+
+  describe '#formatter' do
+    it 'is initially the default' do
+      expect(described_class.new(nil).formatter).to eql(
+        Stoplight::Default::FORMATTER)
+    end
+
+    it 'reads the formatter' do
+      formatter = proc {}
+      expect(described_class.new(nil, formatter).formatter).to eql(formatter)
+    end
+  end
+
+  describe '#options' do
+    it 'is initially the default' do
+      expect(described_class.new(nil).options).to eql(
+        Stoplight::Notifier::Honeybadger::DEFAULT_OPTIONS)
+    end
+
+    it 'reads the options' do
+      options = { key: :value }
+      expect(described_class.new(nil, nil, options).options).to eql(
+        Stoplight::Notifier::Honeybadger::DEFAULT_OPTIONS.merge(options))
+    end
+  end
+
+  describe '#notify' do
+    let(:light) { Stoplight::Light.new(name, &code) }
+    let(:name) { ('a'..'z').to_a.shuffle.join }
+    let(:code) { -> {} }
+    let(:from_color) { Stoplight::Color::GREEN }
+    let(:to_color) { Stoplight::Color::RED }
+    let(:notifier) { described_class.new(api_key) }
+    let(:api_key) { ('a'..'z').to_a.shuffle.join }
+
+    before do
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'returns the message' do
+      error = nil
+      message = notifier.formatter.call(light, from_color, to_color, error)
+      expect(notifier.notify(light, from_color, to_color, error)).to eql(
+        message)
+      expect(Honeybadger).to have_received(:notify).with(
+        hash_including(
+          api_key: api_key,
+          error_message: message))
+    end
+
+    it 'returns the message with an error' do
+      error = ZeroDivisionError.new('divided by 0')
+      message = notifier.formatter.call(light, from_color, to_color, error)
+      expect(notifier.notify(light, from_color, to_color, error)).to eql(
+        message)
+      expect(Honeybadger).to have_received(:notify).with(
+        hash_including(
+          api_key: api_key,
+          error_message: message,
+          backtrace: error.backtrace))
+    end
+  end
+end

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |gem|
     'guard-rspec' => '4.6',
     'guard-rubocop' => '1.2',
     'hipchat' => '1.5',
+    'honeybadger' => '2.1',
     'rake' => '10.4',
     'redis' => '3.2',
     'rspec' => '3.3',


### PR DESCRIPTION
This pull request fixes #79. It adds a notifier for the Honeybadger error reporting service. 