### PR TITLE
Don't unnecessarily import gems

### DIFF
--- a/spec/stoplight/notifier/bugsnag_spec.rb
+++ b/spec/stoplight/notifier/bugsnag_spec.rb
@@ -1,7 +1,10 @@
 # coding: utf-8
 
 require 'spec_helper'
-require 'bugsnag'
+
+# require 'bugsnag'
+module Bugsnag
+end
 
 RSpec.describe Stoplight::Notifier::Bugsnag do
   StoplightStatusChange = Stoplight::Notifier::Bugsnag::StoplightStatusChange
@@ -42,7 +45,7 @@ RSpec.describe Stoplight::Notifier::Bugsnag do
 
   describe '#bugsnag' do
     it 'reads the Bugsnag client' do
-      client = ::Bugsnag
+      client = Bugsnag
       expect(described_class.new(client, nil).bugsnag)
         .to eql(client)
     end
@@ -55,7 +58,7 @@ RSpec.describe Stoplight::Notifier::Bugsnag do
     let(:from_color) { Stoplight::Color::GREEN }
     let(:to_color) { Stoplight::Color::RED }
     let(:notifier) { described_class.new(bugsnag) }
-    let(:bugsnag) { double(Bugsnag) }
+    let(:bugsnag) { Bugsnag }
 
     subject(:result) do
       notifier.notify(light, from_color, to_color, error)

--- a/spec/stoplight/notifier/hip_chat_spec.rb
+++ b/spec/stoplight/notifier/hip_chat_spec.rb
@@ -1,7 +1,14 @@
 # coding: utf-8
 
 require 'spec_helper'
-require 'hipchat'
+
+# require 'hipchat'
+module HipChat
+  class Client
+    def initialize(*)
+    end
+  end
+end
 
 RSpec.describe Stoplight::Notifier::HipChat do
   it 'is a class' do

--- a/spec/stoplight/notifier/honeybadger_spec.rb
+++ b/spec/stoplight/notifier/honeybadger_spec.rb
@@ -1,5 +1,10 @@
+# coding: utf-8
+
 require 'spec_helper'
-require 'honeybadger'
+
+# require 'honeybadger'
+module Honeybadger
+end
 
 RSpec.describe Stoplight::Notifier::Honeybadger do
   it 'is a class' do

--- a/spec/stoplight/notifier/logger_spec.rb
+++ b/spec/stoplight/notifier/logger_spec.rb
@@ -1,6 +1,8 @@
 # coding: utf-8
 
 require 'spec_helper'
+require 'logger'
+require 'stringio'
 
 RSpec.describe Stoplight::Notifier::Logger do
   it 'is a class' do

--- a/spec/stoplight/notifier/slack_spec.rb
+++ b/spec/stoplight/notifier/slack_spec.rb
@@ -1,7 +1,14 @@
 # coding: utf-8
 
 require 'spec_helper'
-require 'slack-notifier'
+
+# require 'slack-notifier'
+module Slack
+  class Notifier
+    def initialize(*)
+    end
+  end
+end
 
 RSpec.describe Stoplight::Notifier::Slack do
   it_behaves_like 'a generic notifier'


### PR DESCRIPTION
This pull request aims to fix #83. It does so by not requiring the gems that power the notifiers. Since the specs stub them out anyway, they aren't really necessary. 