### PR TITLE
Add blacklisted errors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ a while. (The yellow state corresponds to the half open state for circuit
 
 ### Custom errors
 
+##### Allowed errors
+
 Some errors shouldn't cause your stoplight to move into the red state. Usually
 these are handled elsewhere in your stack and don't represent real failures. A
 good example is `ActiveRecord::RecordNotFound`.
@@ -140,6 +142,44 @@ light.color
 The following errors are always allowed: `NoMemoryError`, `ScriptError`,
 `SecurityError`, `SignalException`, `SystemExit`, and `SystemStackError`.
 
+Allowed errors take precedence over [blacklisted errors](#blacklisted-errors).
+
+##### Blacklisted errors
+
+You may want only certain errors to cause your stoplight to move into the red
+state.
+
+``` rb
+light = Stoplight('example-4') { 1 / 0 }
+  .with_blacklisted_errors([ZeroDivisionError])
+# => #<Stoplight::Light:...>
+light.run
+# ZeroDivisionError: divided by 0
+light.run
+# ZeroDivisionError: divided by 0
+light.run
+# ZeroDivisionError: divided by 0
+light.color
+# => "red"
+```
+
+This will cause all other errors to be raised normally. They won't affect the
+state of your stoplight.
+
+``` rb
+light = Stoplight('example-5') { fail }
+  .with_blacklisted_errors([ZeroDivisionError])
+# => #<Stoplight::Light:...>
+light.run
+# RuntimeError:
+light.run
+# RuntimeError:
+light.run
+# RuntimeError:
+light.color
+# => "green"
+```
+
 ### Custom fallback
 
 By default, stoplights will re-raise errors when they're green. When they're
@@ -148,7 +188,7 @@ fallback that will be called in both of these cases. It will be passed the
 error if the light was green.
 
 ``` rb
-light = Stoplight('example-4') { 1 / 0 }
+light = Stoplight('example-6') { 1 / 0 }
   .with_fallback { |e| p e; 'default' }
 # => #<Stoplight::Light:..>
 light.run
@@ -172,7 +212,7 @@ Some bits of code might be allowed to fail more or less frequently than others.
 You can configure this by setting a custom threshold.
 
 ``` rb
-light = Stoplight('example-5') { fail }
+light = Stoplight('example-7') { fail }
   .with_threshold(1)
 # => #<Stoplight::Light:...>
 light.run
@@ -191,7 +231,7 @@ time. A light in the red state for longer than the timeout will transition to
 the yellow state. This timeout is customizable.
 
 ``` rb
-light = Stoplight('example-6') { fail }
+light = Stoplight('example-8') { fail }
   .with_timeout(1)
 # => #<Stoplight::Light:...>
 light.run
@@ -379,7 +419,7 @@ override the default behavior. You can lock a light in either the green or red
 state using `set_state`.
 
 ``` rb
-light = Stoplight('example-7') { true }
+light = Stoplight('example-9') { true }
 # => #<Stoplight::Light:..>
 light.run
 # => true

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ a while. (The yellow state corresponds to the half open state for circuit
 
 ### Custom errors
 
-##### Allowed errors
+##### Whitelisted errors
 
 Some errors shouldn't cause your stoplight to move into the red state. Usually
 these are handled elsewhere in your stack and don't represent real failures. A
@@ -127,7 +127,7 @@ good example is `ActiveRecord::RecordNotFound`.
 
 ``` rb
 light = Stoplight('example-3') { User.find(123) }
-  .with_allowed_errors([ActiveRecord::RecordNotFound])
+  .with_whitelisted_errors([ActiveRecord::RecordNotFound])
 # => #<Stoplight::Light:...>
 light.run
 # ActiveRecord::RecordNotFound: Couldn't find User with ID=123
@@ -139,10 +139,10 @@ light.color
 # => "green"
 ```
 
-The following errors are always allowed: `NoMemoryError`, `ScriptError`,
+The following errors are always whitelisted: `NoMemoryError`, `ScriptError`,
 `SecurityError`, `SignalException`, `SystemExit`, and `SystemStackError`.
 
-Allowed errors take precedence over [blacklisted errors](#blacklisted-errors).
+Whitelisted errors take precedence over [blacklisted errors](#blacklisted-errors).
 
 ##### Blacklisted errors
 
@@ -267,7 +267,7 @@ class ApplicationController < ActionController::Base
 
   def stoplight(&block)
     Stoplight("#{params[:controller]}##{params[:action]}", &block)
-      .with_allowed_errors([ActiveRecord::RecordNotFound])
+      .with_whitelisted_errors([ActiveRecord::RecordNotFound])
       .with_fallback do |error|
         Rails.logger.error(error)
         render(nothing: true, status: :service_unavailable)

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -11,6 +11,8 @@ module Stoplight
       SystemStackError
     ].freeze
 
+    BLACKLISTED_ERRORS = [].freeze
+
     DATA_STORE = DataStore::Memory.new
 
     ERROR_NOTIFIER = -> error { warn error }

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -2,7 +2,7 @@
 
 module Stoplight
   module Default
-    ALLOWED_ERRORS = [
+    WHITELISTED_ERRORS = [
       NoMemoryError,
       ScriptError,
       SecurityError,

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -5,7 +5,7 @@ module Stoplight
     include Runnable
 
     # @return [Array<Exception>]
-    attr_reader :allowed_errors
+    attr_reader :whitelisted_errors
     # @return [Array<Exception>]
     attr_reader :blacklisted_errors
     # @return [Proc]
@@ -44,7 +44,7 @@ module Stoplight
       @name = name
       @code = code
 
-      @allowed_errors = Default::ALLOWED_ERRORS
+      @whitelisted_errors = Default::WHITELISTED_ERRORS
       @blacklisted_errors = Default::BLACKLISTED_ERRORS
       @data_store = self.class.default_data_store
       @error_notifier = self.class.default_error_notifier
@@ -54,12 +54,14 @@ module Stoplight
       @timeout = Default::TIMEOUT
     end
 
-    # @param allowed_errors [Array<Exception>]
+    # @param whitelisted_errors [Array<Exception>]
     # @return [self]
-    def with_allowed_errors(allowed_errors)
-      @allowed_errors = Default::ALLOWED_ERRORS + allowed_errors
+    def with_whitelisted_errors(whitelisted_errors)
+      @whitelisted_errors = Default::WHITELISTED_ERRORS + whitelisted_errors
       self
     end
+
+    alias_method :with_allowed_errors, :with_whitelisted_errors
 
     # @param blacklisted_errors [Array<Exception>]
     # @return [self]

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -61,7 +61,7 @@ module Stoplight
       self
     end
 
-    alias_method :with_allowed_errors, :with_whitelisted_errors
+    alias with_allowed_errors with_whitelisted_errors
 
     # @param blacklisted_errors [Array<Exception>]
     # @return [self]

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -6,6 +6,8 @@ module Stoplight
 
     # @return [Array<Exception>]
     attr_reader :allowed_errors
+    # @return [Array<Exception>]
+    attr_reader :blacklisted_errors
     # @return [Proc]
     attr_reader :code
     # @return [DataStore::Base]
@@ -43,6 +45,7 @@ module Stoplight
       @code = code
 
       @allowed_errors = Default::ALLOWED_ERRORS
+      @blacklisted_errors = Default::BLACKLISTED_ERRORS
       @data_store = self.class.default_data_store
       @error_notifier = self.class.default_error_notifier
       @fallback = Default::FALLBACK
@@ -55,6 +58,13 @@ module Stoplight
     # @return [self]
     def with_allowed_errors(allowed_errors)
       @allowed_errors = Default::ALLOWED_ERRORS + allowed_errors
+      self
+    end
+
+    # @param blacklisted_errors [Array<Exception>]
+    # @return [self]
+    def with_blacklisted_errors(blacklisted_errors)
+      @blacklisted_errors = Default::BLACKLISTED_ERRORS + blacklisted_errors
       self
     end
 

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -56,8 +56,14 @@ module Stoplight
         handle_error(error, on_failure)
       end
 
+      def not_blacklisted_error?(error)
+        blacklisted_errors.length > 0 &&
+          blacklisted_errors.none? { |klass| error.is_a?(klass) }
+      end
+
       def handle_error(error, on_failure)
         fail error if allowed_errors.any? { |klass| error.is_a?(klass) }
+        fail error if not_blacklisted_error?(error)
         size = record_failure(error)
         on_failure.call(size, error) if on_failure
         fail error unless fallback

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -62,7 +62,7 @@ module Stoplight
       end
 
       def handle_error(error, on_failure)
-        fail error if allowed_errors.any? { |klass| error.is_a?(klass) }
+        fail error if whitelisted_errors.any? { |klass| error.is_a?(klass) }
         fail error if not_blacklisted_error?(error)
         size = record_failure(error)
         on_failure.call(size, error) if on_failure

--- a/spec/stoplight/default_spec.rb
+++ b/spec/stoplight/default_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe Stoplight::Default do
     end
   end
 
+  describe '::BLACKLISTED_ERRORS' do
+    it 'is an array' do
+      expect(Stoplight::Default::BLACKLISTED_ERRORS).to be_an(Array)
+    end
+
+    it 'is empty' do
+      expect(Stoplight::Default::BLACKLISTED_ERRORS).to be_empty
+    end
+
+    it 'is frozen' do
+      expect(Stoplight::Default::BLACKLISTED_ERRORS).to be_frozen
+    end
+  end
+
   describe '::DATA_STORE' do
     it 'is a data store' do
       expect(Stoplight::Default::DATA_STORE).to be_a(Stoplight::DataStore::Base)

--- a/spec/stoplight/default_spec.rb
+++ b/spec/stoplight/default_spec.rb
@@ -7,19 +7,19 @@ RSpec.describe Stoplight::Default do
     expect(described_class).to be_a(Module)
   end
 
-  describe '::ALLOWED_ERRORS' do
+  describe '::WHITELISTED_ERRORS' do
     it 'is an array' do
-      expect(Stoplight::Default::ALLOWED_ERRORS).to be_an(Array)
+      expect(Stoplight::Default::WHITELISTED_ERRORS).to be_an(Array)
     end
 
     it 'contains exception classes' do
-      Stoplight::Default::ALLOWED_ERRORS.each do |allowed_error|
-        expect(allowed_error).to be < Exception
+      Stoplight::Default::WHITELISTED_ERRORS.each do |whitelisted_error|
+        expect(whitelisted_error).to be < Exception
       end
     end
 
     it 'is frozen' do
-      expect(Stoplight::Default::ALLOWED_ERRORS).to be_frozen
+      expect(Stoplight::Default::WHITELISTED_ERRORS).to be_frozen
     end
   end
 

--- a/spec/stoplight/light/runnable_spec.rb
+++ b/spec/stoplight/light/runnable_spec.rb
@@ -119,10 +119,10 @@ RSpec.describe Stoplight::Light::Runnable do
           expect(io.string).to_not eql('')
         end
 
-        context 'when the error is allowed' do
-          let(:allowed_errors) { [error.class] }
+        context 'when the error is whitelisted' do
+          let(:whitelisted_errors) { [error.class] }
 
-          before { subject.with_allowed_errors(allowed_errors) }
+          before { subject.with_whitelisted_errors(whitelisted_errors) }
 
           it 'does not record the failure' do
             expect(subject.data_store.get_failures(subject).size).to eql(0)
@@ -183,13 +183,13 @@ RSpec.describe Stoplight::Light::Runnable do
           end
         end
 
-        context 'when the error is both allowed and blacklisted' do
-          let(:allowed_errors) { [error.class] }
+        context 'when the error is both whitelisted and blacklisted' do
+          let(:whitelisted_errors) { [error.class] }
           let(:blacklisted_errors) { [error.class] }
 
           before do
             subject
-              .with_allowed_errors(allowed_errors)
+              .with_whitelisted_errors(whitelisted_errors)
               .with_blacklisted_errors(blacklisted_errors)
           end
 

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -67,9 +67,11 @@ RSpec.describe Stoplight::Light do
     end
   end
 
-  describe '#allowed_errors' do
+  describe '#whitelisted_errors' do
     it 'is initially the default' do
-      expect(light.allowed_errors).to eql(Stoplight::Default::ALLOWED_ERRORS)
+      expect(light.whitelisted_errors).to eql(
+        Stoplight::Default::WHITELISTED_ERRORS
+      )
     end
   end
 
@@ -130,12 +132,30 @@ RSpec.describe Stoplight::Light do
     end
   end
 
+  describe '#with_whitelisted_errors' do
+    it 'adds the whitelisted errors to the default' do
+      whitelisted_errors = [StandardError]
+      light.with_whitelisted_errors(whitelisted_errors)
+      expect(light.whitelisted_errors)
+        .to eql(Stoplight::Default::WHITELISTED_ERRORS + whitelisted_errors)
+    end
+  end
+
   describe '#with_allowed_errors' do
-    it 'adds the allowed errors to the default' do
+    it 'sets whitelisted_errors' do
       allowed_errors = [StandardError]
       light.with_allowed_errors(allowed_errors)
-      expect(light.allowed_errors)
-        .to eql(Stoplight::Default::ALLOWED_ERRORS + allowed_errors)
+      expect(light.whitelisted_errors)
+        .to eql(Stoplight::Default::WHITELISTED_ERRORS + allowed_errors)
+    end
+  end
+
+  describe '#with_blacklisted_errors' do
+    it 'adds the blacklisted errors to the default' do
+      blacklisted_errors = [StandardError]
+      light.with_blacklisted_errors(blacklisted_errors)
+      expect(light.blacklisted_errors)
+        .to eql(Stoplight::Default::BLACKLISTED_ERRORS + blacklisted_errors)
     end
   end
 

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe Stoplight::Light do
     end
   end
 
+  describe '#blacklisted_errors' do
+    it 'is initially the default' do
+      expect(light.blacklisted_errors).to eql(
+        Stoplight::Default::BLACKLISTED_ERRORS
+      )
+    end
+  end
+
   describe '#code' do
     it 'reads the code' do
       expect(light.code).to eql(code)


### PR DESCRIPTION
I've come across a situation where I would only like one or two types of errors to change the state of the stoplight. Currently, I would have to use the `.with_allowed_errors` method to whitelist all the other errors that could potentially occur. This adds a `.with_blacklisted_errors` method that essentially does the opposite. You can specify error classes that should affect the stoplight state, and all other errors will be raised normally.

It's important to note a couple things:

- If `blacklisted_errors` is empty (which is the default), the stoplight will behave the same way it currently does
- If an error is both allowed and blacklisted, it will not affect the state of the stoplight—`allowed_errors` takes precedence over `blacklisted_errors`