### PR TITLE
Rescues all blacklisted errors

### DIFF
--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -52,7 +52,7 @@ module Stoplight
         failures = clear_failures
         on_success.call(failures) if on_success
         result
-      rescue => error
+      rescue *[StandardError].concat(blacklisted_errors) => error
         handle_error(error, on_failure)
       end
 

--- a/spec/stoplight/light/runnable_spec.rb
+++ b/spec/stoplight/light/runnable_spec.rb
@@ -151,6 +151,23 @@ RSpec.describe Stoplight::Light::Runnable do
           end
         end
 
+        context 'when the error is a blacklisted of Exception class' do
+          let(:error_class) { Class.new(Exception) }
+          let(:blacklisted_errors) { [error.class] }
+
+          before { subject.with_blacklisted_errors(blacklisted_errors) }
+
+          it 'records the failure' do
+            expect(subject.data_store.get_failures(subject).size).to eql(0)
+            begin
+              subject.run
+            rescue error.class
+              nil
+            end
+            expect(subject.data_store.get_failures(subject).size).to eql(1)
+          end
+        end
+
         context 'when the error is not blacklisted' do
           let(:blacklisted_errors) { [RuntimeError] }
 


### PR DESCRIPTION
When blacklisting an error that inherited from Exception Class Stoplight would fail to rescue this error because it only rescues StandardError. The proposed solution is to rescue from any blacklisted_errors, in addition to StandardError.