### PR TITLE
I am suggesting a change to the whitelisting and blacklisting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Some errors shouldn't cause your stoplight to move into the red state. Usually
 these are handled elsewhere in your stack and don't represent real failures. A
 good example is `ActiveRecord::RecordNotFound`.
 
+By default all errors that inherit from StandardError will be caught by stoplight. 
+To ignore specific errors add them to the whitelist.
+
 ``` rb
 light = Stoplight('example-not-found') { User.find(123) }
   .with_whitelisted_errors([ActiveRecord::RecordNotFound])
@@ -139,27 +142,26 @@ light.color
 # => "green"
 ```
 
-The following errors are always whitelisted: `NoMemoryError`, `ScriptError`,
-`SecurityError`, `SignalException`, `SystemExit`, and `SystemStackError`.
-
 Whitelisted errors take precedence over [blacklisted errors](#blacklisted-errors).
 
 #### Blacklisted errors
 
-You may want only certain errors to cause your stoplight to move into the red
-state.
+By default errors that inherit from `Exception`, other than `StandardError`, are not caught by Stoplight. This is because
+this would catch errors like `Interrupt`, when Ctrl-C is hit, and `NoMemoryError`. Never the less
+there may be times when you need Stoplight to catch a child of `Exception`, to do so add it to
+the blacklist.
 
 ``` rb
 light = Stoplight('example-blacklist-zero') { 1 / 0 }
-  .with_blacklisted_errors([ZeroDivisionError])
+  .with_blacklisted_errors([SystemExit])
 # => #<Stoplight::Light:...>
 light.run
-# ZeroDivisionError: divided by 0
+# SystemExit: divided by 0
 light.run
-# ZeroDivisionError: divided by 0
+# SystemExit: divided by 0
 light.run
 # Switching example-blacklist-zero from green to red because ZeroDivisionError divided by 0
-# ZeroDivisionError: divided by 0
+# SystemExit: divided by 0
 light.color
 # => "red"
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check out [stoplight-admin][] for controlling your stoplights.
   - [Custom fallback](#custom-fallback)
   - [Custom threshold](#custom-threshold)
   - [Custom timeout](#custom-timeout)
+  - [Custom error handler](#custom-error-handler)
   - [Rails](#rails)
 - [Setup](#setup)
   - [Data store](#data-store)
@@ -125,7 +126,7 @@ Some errors shouldn't cause your stoplight to move into the red state. Usually
 these are handled elsewhere in your stack and don't represent real failures. A
 good example is `ActiveRecord::RecordNotFound`.
 
-By default all errors that inherit from `StandardError` will be caught by stoplight. 
+By default all errors that inherit from StandardError will be caught by stoplight. 
 To ignore specific errors add them to the whitelist.
 
 ``` rb

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Some errors shouldn't cause your stoplight to move into the red state. Usually
 these are handled elsewhere in your stack and don't represent real failures. A
 good example is `ActiveRecord::RecordNotFound`.
 
-By default all errors that inherit from StandardError will be caught by stoplight. 
+By default all errors that inherit from `StandardError` will be caught by stoplight. 
 To ignore specific errors add them to the whitelist.
 
 ``` rb

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -2,16 +2,9 @@
 
 module Stoplight
   module Default
-    WHITELISTED_ERRORS = [
-      NoMemoryError,
-      ScriptError,
-      SecurityError,
-      SignalException,
-      SystemExit,
-      SystemStackError
-    ].freeze
+    WHITELISTED_ERRORS = [].freeze
 
-    BLACKLISTED_ERRORS = [].freeze
+    BLACKLISTED_ERRORS = [StandardError].freeze
 
     DATA_STORE = DataStore::Memory.new
 

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -4,9 +4,7 @@ module Stoplight
   module Default
     WHITELISTED_ERRORS = [].freeze
 
-    BLACKLISTED_ERRORS = [
-      StandardError
-    ].freeze
+    BLACKLISTED_ERRORS = [].freeze
 
     DATA_STORE = DataStore::Memory.new
 
@@ -27,5 +25,16 @@ module Stoplight
     THRESHOLD = 3
 
     TIMEOUT = 60.0
+
+    # Taken from rspec-support
+    module AllExceptionsExceptOnesWeMustNotRescue
+      # These exceptions are dangerous to rescue as rescuing them
+      # would interfere with things we should not interfere with.
+      AVOID_RESCUING = [NoMemoryError, SignalException, Interrupt, SystemExit]
+
+      def self.===(exception)
+        AVOID_RESCUING.none? { |ar| ar === exception }
+      end
+    end
   end
 end

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -4,7 +4,9 @@ module Stoplight
   module Default
     WHITELISTED_ERRORS = [].freeze
 
-    BLACKLISTED_ERRORS = [StandardError].freeze
+    BLACKLISTED_ERRORS = [
+      StandardError
+    ].freeze
 
     DATA_STORE = DataStore::Memory.new
 

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -24,6 +24,8 @@ module Stoplight
     attr_reader :threshold
     # @return [Float]
     attr_reader :timeout
+    # @return [Proc]
+    attr_reader :error_handler
 
     class << self
       # @return [DataStore::Base]
@@ -109,6 +111,13 @@ module Stoplight
     # @return [self]
     def with_timeout(timeout)
       @timeout = timeout
+      self
+    end
+
+    # @param error_handler [Proc]
+    # @return [self]
+    def with_error_handler(error_handler)
+      @error_handler = error_handler
       self
     end
   end

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -52,7 +52,7 @@ module Stoplight
         failures = clear_failures
         on_success.call(failures) if on_success
         result
-      rescue *[StandardError].concat(blacklisted_errors) => error
+      rescue *blacklisted_errors => error
         handle_error(error, on_failure)
       end
 
@@ -63,7 +63,6 @@ module Stoplight
 
       def handle_error(error, on_failure)
         raise error if whitelisted_errors.any? { |klass| error.is_a?(klass) }
-        raise error if not_blacklisted_error?(error)
         size = record_failure(error)
         on_failure.call(size, error) if on_failure
         raise error unless fallback

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -52,7 +52,7 @@ module Stoplight
         failures = clear_failures
         on_success.call(failures) if on_success
         result
-      rescue *blacklisted_errors => error
+      rescue Default::AllExceptionsExceptOnesWeMustNotRescue => error
         handle_error(error, on_failure)
       end
 
@@ -62,7 +62,13 @@ module Stoplight
       end
 
       def handle_error(error, on_failure)
-        raise error if whitelisted_errors.any? { |klass| error.is_a?(klass) }
+        default_error_handler = -> (error:, **_) do
+          raise error if whitelisted_errors.any? { |klass| error.is_a?(klass) }
+          raise error if not_blacklisted_error?(error)
+        end
+        (error_handler || default_error_handler).call(error:              error,
+                                                      whitelisted_errors: whitelisted_errors,
+                                                      blacklisted_errors: blacklisted_errors)
         size = record_failure(error)
         on_failure.call(size, error) if on_failure
         raise error unless fallback

--- a/spec/stoplight/default_spec.rb
+++ b/spec/stoplight/default_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Stoplight::Default do
 
     it 'contains exception classes' do
       Stoplight::Default::WHITELISTED_ERRORS.each do |whitelisted_error|
-        expect(whitelisted_error).to be < Exception
+        expect(whitelisted_error).to be < StandardError
       end
     end
 
@@ -26,10 +26,6 @@ RSpec.describe Stoplight::Default do
   describe '::BLACKLISTED_ERRORS' do
     it 'is an array' do
       expect(Stoplight::Default::BLACKLISTED_ERRORS).to be_an(Array)
-    end
-
-    it 'is empty' do
-      expect(Stoplight::Default::BLACKLISTED_ERRORS).to be_empty
     end
 
     it 'is frozen' do

--- a/spec/stoplight/light/runnable_spec.rb
+++ b/spec/stoplight/light/runnable_spec.rb
@@ -151,26 +151,8 @@ RSpec.describe Stoplight::Light::Runnable do
           end
         end
 
-        context 'when the error is a blacklisted of Exception class' do
-          let(:error_class) { Class.new(Exception) }
-          let(:blacklisted_errors) { [error.class] }
-
-          before { subject.with_blacklisted_errors(blacklisted_errors) }
-
-          it 'records the failure' do
-            expect(subject.data_store.get_failures(subject).size).to eql(0)
-            begin
-              subject.run
-            rescue error.class
-              nil
-            end
-            expect(subject.data_store.get_failures(subject).size).to eql(1)
-          end
-        end
-
         context 'when the error is not blacklisted' do
-          let(:error_class) { Class.new(Exception) }
-          let(:blacklisted_errors) { [] }
+          let(:blacklisted_errors) { [RuntimeError] }
 
           before { subject.with_blacklisted_errors(blacklisted_errors) }
 
@@ -219,6 +201,54 @@ RSpec.describe Stoplight::Light::Runnable do
               nil
             end
             expect(subject.data_store.get_failures(subject).size).to eql(0)
+          end
+        end
+
+        context 'when using user provided error handler' do
+          let(:whitelisted_errors) { [error.class] }
+          let(:blacklisted_errors) { [error.class] }
+          let(:error_handler){double("error_handlers")}
+
+          before do
+            subject
+              .with_error_handler(error_handler)
+              .with_whitelisted_errors(whitelisted_errors)
+              .with_blacklisted_errors(blacklisted_errors)
+          end
+
+          it 'does record the failure' do
+            allow(error_handler).to receive(:call) do |error:, **args|
+              raise error
+            end
+            expect(subject.data_store.get_failures(subject).size).to eql(0)
+            begin
+              subject.run
+            rescue error.class
+              nil
+            end
+            expect(subject.data_store.get_failures(subject).size).to eql(0)
+          end
+
+          it 'sends the correct arguments to custom error handler' do
+            expect(error_handler).to receive(:call).with(error:              error,
+                                                         blacklisted_errors: blacklisted_errors,
+                                                         whitelisted_errors: whitelisted_errors)
+            begin
+              subject.run
+            rescue error.class
+              nil
+            end
+          end
+
+          it 'does not record the failure' do
+            allow(error_handler).to receive(:call).and_return(true)
+            expect(subject.data_store.get_failures(subject).size).to eql(0)
+            begin
+              subject.run
+            rescue error.class
+              nil
+            end
+            expect(subject.data_store.get_failures(subject).size).to eql(1)
           end
         end
 

--- a/spec/stoplight/light/runnable_spec.rb
+++ b/spec/stoplight/light/runnable_spec.rb
@@ -169,7 +169,8 @@ RSpec.describe Stoplight::Light::Runnable do
         end
 
         context 'when the error is not blacklisted' do
-          let(:blacklisted_errors) { [RuntimeError] }
+          let(:error_class) { Class.new(Exception) }
+          let(:blacklisted_errors) { [] }
 
           before { subject.with_blacklisted_errors(blacklisted_errors) }
 

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -206,4 +206,12 @@ RSpec.describe Stoplight::Light do
       expect(light.timeout).to eql(timeout)
     end
   end
+
+  describe '#with_error_handler' do
+    it 'sets the error handler' do
+      error_handler = -> () {  }
+      light.with_error_handler(error_handler)
+      expect(light.error_handler).to eql(error_handler)
+    end
+  end
 end


### PR DESCRIPTION
Issues with former code:
* Any whited listed errors that didn't inherit from `StandardError` were not being rescued.

Suggested Solution:
Change the whitelist to be a whitelist of `StandardError` errors.
Change the blacklist to be a blacklist of not `StandardError` errors or `Exception` errors.