### PR TITLE
Add support ActiveSupport::Testing::TimeHelpers

### DIFF
--- a/lib/stoplight/failure.rb
+++ b/lib/stoplight/failure.rb
@@ -15,7 +15,7 @@ module Stoplight
     # @param error [Exception]
     # @return (see #initialize)
     def self.from_error(error)
-      new(error.class.name, error.message, Time.new)
+      new(error.class.name, error.message, Time.now)
     end
 
     # @param json [String]

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -12,7 +12,7 @@ module Stoplight
         when state == State::LOCKED_GREEN then Color::GREEN
         when state == State::LOCKED_RED then Color::RED
         when failures.size < threshold then Color::GREEN
-        when failure && Time.new - failure.time >= cool_off_time
+        when failure && Time.now - failure.time >= cool_off_time
           Color::YELLOW
         else Color::RED
         end


### PR DESCRIPTION
ActiveSupport::Testing::TimeHelpers stubs `Time.now` automatically, so Timecop
won't be a required dependency when testing Stoplight inside of a gem
consumer's project.

------

Thanks for making this gem! If you have any specific contributor guidelines that I haven't followed, just let me know.