### PR TITLE
Add timeout option

### DIFF
--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -23,5 +23,7 @@ module Stoplight
     ].freeze
 
     THRESHOLD = 3
+
+    TIMEOUT = 1000
   end
 end

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -22,6 +22,8 @@ module Stoplight
     attr_reader :notifiers
     # @return [Fixnum]
     attr_reader :threshold
+    # @return [Fixnum]
+    attr_reader :timeout
 
     class << self
       # @return [DataStore::Base]
@@ -49,6 +51,7 @@ module Stoplight
       @fallback = Default::FALLBACK
       @notifiers = self.class.default_notifiers
       @threshold = Default::THRESHOLD
+      @timeout = Default::TIMEOUT
     end
 
     # @param cool_off_time [Float]
@@ -98,6 +101,13 @@ module Stoplight
     # @return [self]
     def with_threshold(threshold)
       @threshold = threshold
+      self
+    end
+
+    # @param timeout [Fixnum]
+    # @return [self]
+    def with_timeout(timeout)
+      @timeout = timeout
       self
     end
   end

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -48,12 +48,18 @@ module Stoplight
       end
 
       def run_code(on_success, on_failure)
-        result = code.call
+        result = execute_with_timeout { code.call }
         failures = clear_failures
         on_success.call(failures) if on_success
         result
       rescue Exception => error # rubocop:disable Lint/RescueException
         handle_error(error, on_failure)
+      end
+
+      def execute_with_timeout
+        Timeout.timeout(timeout) do
+          yield
+        end
       end
 
       def handle_error(error, on_failure)

--- a/spec/stoplight/light/runnable_spec.rb
+++ b/spec/stoplight/light/runnable_spec.rb
@@ -167,6 +167,16 @@ RSpec.describe Stoplight::Light::Runnable do
             expect(subject.run).to eql(fallback_result)
           end
         end
+
+        context 'when timeout is reached' do
+          let(:code) { -> { sleep 1 } }
+
+          before { subject.with_timeout(0.1).with_fallback(&fallback) }
+
+          it 'runs the fallback' do
+            expect(subject.run).to eql(fallback_result)
+          end
+        end
       end
 
       context 'when the data store is failing' do

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -177,4 +177,12 @@ RSpec.describe Stoplight::Light do
       expect(light.threshold).to eql(threshold)
     end
   end
+
+  describe '#with_timeout' do
+    it 'sets the timeout' do
+      timeout = 3
+      light.with_timeout(timeout)
+      expect(light.timeout).to eq(timeout)
+    end
+  end
 end


### PR DESCRIPTION
I like this gem and trying to use in some projects! Good work community :)

Some days ago, i've found a interesting property in Hystrix:
"execution.isolation.thread.timeoutInMilliseconds

This property sets the time in milliseconds after which the caller will observe a timeout and walk away from the command execution."

I now, this gem isn't Hystrix, but adding timeout limit can you avoid latency (in some cases) and cascading failures. 

I suggest this code, but it's only an opinion of a paltry dev :)

Thanks for all.