### PR TITLE
Add data dog notifier

### DIFF
--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -26,6 +26,7 @@ require 'stoplight/notifier/io'
 require 'stoplight/notifier/logger'
 require 'stoplight/notifier/raven'
 require 'stoplight/notifier/slack'
+require 'stoplight/notifier/data_dog_service_check'
 
 require 'stoplight/default'
 

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -42,7 +42,11 @@ module Stoplight
         @options = @options.merge({message: formatter.call(light, from_color, to_color, error)})
         if light.color == Color::GREEN
           status = 0
+        elsif light.color == Color::YELLOW
+          status = 1
         elsif light.color == Color::RED
+          status = 2
+        else
           status = 3
         end
         options[:timestamp] = options[:timestamp].to_i

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -32,7 +32,7 @@ module Stoplight
       def initialize(api_key, host, prefix, formatter = nil, options = nil)
         @api_key = api_key
         @prefix = prefix
-        @host= host
+        @host = host
         @formatter = formatter || Default::FORMATTER
         @options = DEFAULT_OPTIONS.merge(options)
         @dog = Dogapi::Client.new(api_key)

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -32,7 +32,7 @@ module Stoplight
       def initialize(api_key, check, host_name, formatter = nil, options = nil)
         @api_key = api_key
         @check = check
-        @hostname = host_name
+        @host_name = host_name
         @formatter = formatter || Default::FORMATTER
         @options = DEFAULT_OPTIONS.merge(options)
         @dog = Dogapi::Client.new(api_key)

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -29,7 +29,7 @@ module Stoplight
       # @param options [Hash{Symbol => Object}]
       # @option options [Time] :timestamp
       # @option options [Hash] :tags
-      def initialize(api_key, prefix = '', host_name, formatter = nil, options = nil)
+      def initialize(api_key, host_name, prefix = '', formatter = nil, options = nil)
         @api_key = api_key
         @prefix = prefix
         @host_name = host_name

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+module Stoplight
+  module Notifier
+    # @see Base
+    class DataDogServiceCheck < Base
+      DEFAULT_OPTIONS = {
+        timestamp: Time.now,
+        tags: {}
+      }.freeze
+
+      # @return [String]
+      attr_reader :api_key
+      # @return [Proc]
+      attr_reader :formatter
+      # @return[Hash{Symbol => Object}]
+      attr_reader :options
+      # @return [Object]
+      attr_reader :dog
+      # @return [String]
+      attr_reader :check
+      # @return [String]
+      attr_reader :host_name
+
+      # @param api_key [String]
+      # @param check [String]
+      # @param host_name [String]
+      # @param formatter [Proc, nil]
+      # @param options [Hash{Symbol => Object}]
+      # @option options [Time] :timestamp
+      # @option options [Hash] :tags
+      def initialize(api_key, check, host_name, formatter = nil, options = nil)
+        @api_key = api_key
+        @check = check
+        @hostname = host_name
+        @formatter = formatter || Default::FORMATTER
+        @options = DEFAULT_OPTIONS.merge(options)
+        @dog = Dogapi::Client.new(api_key)
+      end
+
+      def notify(light, from_color, to_color, error)
+        @options = @options.merge(message: formatter.call(light, from_color, to_color, error))
+        if light.color == Color::GREEN
+          status = 0
+        elsif light.color == Color::RED
+          status = 3
+        end
+        options[:timestamp] = options[:timestamp].to_i
+        dog.service_check(check, host_name, status, options)
+      end
+    end
+  end
+end

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -29,9 +29,9 @@ module Stoplight
       # @param options [Hash{Symbol => Object}]
       # @option options [Time] :timestamp
       # @option options [Hash] :tags
-      def initialize(api_key, check, host_name, formatter = nil, options = nil)
+      def initialize(api_key, prefix = '', host_name, formatter = nil, options = nil)
         @api_key = api_key
-        @check = check
+        @prefix = prefix
         @host_name = host_name
         @formatter = formatter || Default::FORMATTER
         @options = DEFAULT_OPTIONS.merge(options)
@@ -39,13 +39,14 @@ module Stoplight
       end
 
       def notify(light, from_color, to_color, error)
-        @options = @options.merge(message: formatter.call(light, from_color, to_color, error))
+        @options = @options.merge({message: formatter.call(light, from_color, to_color, error)})
         if light.color == Color::GREEN
           status = 0
         elsif light.color == Color::RED
           status = 3
         end
         options[:timestamp] = options[:timestamp].to_i
+        check = @prefix.empty? ? 'stoplight.' + light.name : prefix + '.' + light.name
         dog.service_check(check, host_name, status, options)
       end
     end

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -52,9 +52,8 @@ module Stoplight
       def get_status(color)
         case color
         when Color::GREEN then 0
-        when Color::YELLOW then 1
         when Color::RED then 2
-        else 3
+        else 1
         end
       end
     end

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -9,33 +9,30 @@ module Stoplight
         tags: {}
       }.freeze
 
-      # @return [String]
-      attr_reader :api_key
       # @return [Proc]
       attr_reader :formatter
+      # @return [::Dogapi::Client]
+      attr_reader :dogapi
       # @return[Hash{Symbol => Object}]
       attr_reader :options
-      # @return [Object]
-      attr_reader :dog
       # @return [String]
       attr_reader :prefix
       # @return [String]
       attr_reader :host
 
-      # @param api_key [String]
-      # @param check [String]
-      # @param host_name [String]
+      # @param dogapi [::Dogapi::Client]
+      # @param prefix [String]
+      # @param host [String]
       # @param formatter [Proc, nil]
       # @param options [Hash{Symbol => Object}]
       # @option options [Time] :timestamp
       # @option options [Hash] :tags
-      def initialize(api_key, host, prefix, formatter = nil, options = nil)
-        @api_key = api_key
-        @prefix = prefix
+      def initialize(dogapi, host, prefix, formatter = nil, options = {})
+        @dogapi = dogapi
         @host = host
+        @prefix = prefix
         @formatter = formatter || Default::FORMATTER
         @options = DEFAULT_OPTIONS.merge(options)
-        @dog = Dogapi::Client.new(api_key)
       end
 
       def notify(light, from_color, to_color, error)
@@ -44,7 +41,8 @@ module Stoplight
           message: message,
           timestamp: options[:timestamp].to_i
         )
-        dog.service_check(check(light), host, get_status(light.color), opts)
+        dogapi.service_check(check(light), host, get_status(light.color), opts)
+        message
       end
 
       def check(light)

--- a/lib/stoplight/notifier/data_dog_service_check.rb
+++ b/lib/stoplight/notifier/data_dog_service_check.rb
@@ -18,7 +18,7 @@ module Stoplight
       # @return [Object]
       attr_reader :dog
       # @return [String]
-      attr_reader :check
+      attr_reader :prefix
       # @return [String]
       attr_reader :host_name
 

--- a/spec/stoplight/notifier/data_dog_service_check_spec.rb
+++ b/spec/stoplight/notifier/data_dog_service_check_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
       expect(described_class
         .new(nil, host, prefix, nil, options).options)
         .to eql(
-        Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS.merge(options)
-      )
+          Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS.merge(options)
+        )
     end
   end
 

--- a/spec/stoplight/notifier/data_dog_service_check_spec.rb
+++ b/spec/stoplight/notifier/data_dog_service_check_spec.rb
@@ -95,10 +95,16 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
       expect(notifier.get_status(light.color)).to eql(0)
     end
 
-    context 'after the stoplight is red' do
+    context 'when the stoplight is yellow' do
+      it 'returns 1' do
+        expect(notifier.get_status('yellow')).to eql(1)
+      end
+    end
+
+    context 'when the stoplight is red' do
       let(:light) { Stoplight::Light.new(name, &code).with_threshold(0) }
       let(:code) { -> { 0 / 0 } }
-      it 'returns 2 for a broken stoplight' do
+      it 'returns 2' do
         expect(notifier.get_status(light.color)).to eql(2)
       end
     end

--- a/spec/stoplight/notifier/data_dog_service_check_spec.rb
+++ b/spec/stoplight/notifier/data_dog_service_check_spec.rb
@@ -11,8 +11,8 @@ module Dogapi
 end
 
 RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
-  $prefix = 'stoplight'
-  $host = 'myhostname'
+  prefix = 'stoplight'
+  host = 'myhostname'
   it 'is a class' do
     expect(described_class).to be_a(Class)
   end
@@ -23,27 +23,31 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
 
   describe '#formatter' do
     it 'is initially the default' do
-      expect(described_class.new(nil, $host, $prefix).formatter).to eql(
+      expect(described_class.new(nil, host, prefix).formatter).to eql(
         Stoplight::Default::FORMATTER
       )
     end
 
     it 'reads the formatter' do
       formatter = proc {}
-      expect(described_class.new(nil, $host, $prefix, formatter).formatter).to eql(formatter)
+      expect(described_class
+        .new(nil, host, prefix, formatter).formatter)
+        .to eql(formatter)
     end
   end
 
   describe '#options' do
     it 'is intiially the default' do
-      expect(described_class.new(nil, $host, $prefix).options).to eql(
+      expect(described_class.new(nil, host, prefix).options).to eql(
         Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS
       )
     end
 
     it 'reads the options' do
       options = { key: :value }
-      expect(described_class.new(nil, $host, $prefix, nil, options).options).to eql(
+      expect(described_class
+        .new(nil, host, prefix, nil, options).options)
+        .to eql(
         Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS.merge(options)
       )
     end
@@ -52,20 +56,20 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
   describe '#dogapi' do
     it 'reads the Dogapi client' do
       dogapi = Dogapi::Client.new('API token')
-      expect(described_class.new(dogapi, $host, $prefix).dogapi)
+      expect(described_class.new(dogapi, host, prefix).dogapi)
         .to eql(dogapi)
     end
   end
 
   describe '#host' do
     it 'reads the host' do
-      expect(described_class.new(nil, $host, $prefix).host).to eql($host)
+      expect(described_class.new(nil, host, prefix).host).to eql(host)
     end
   end
 
   describe '#prefix' do
     it 'reads the prefix' do
-      expect(described_class.new(nil, $host, $prefix).prefix).to eql($prefix)
+      expect(described_class.new(nil, host, prefix).prefix).to eql(prefix)
     end
   end
 
@@ -73,10 +77,10 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
     let(:light) { Stoplight::Light.new(name, &code) }
     let(:name) { ('a'..'z').to_a.shuffle.join }
     let(:code) { -> {} }
-    let(:notifier) { described_class.new(nil, $host, $prefix) }
+    let(:notifier) { described_class.new(nil, host, prefix) }
 
     it 'returns the prefix combined with the stoplight name' do
-      expect(notifier.check(light)).to eql($prefix + '.' + name)
+      expect(notifier.check(light)).to eql(prefix + '.' + name)
     end
   end
 
@@ -84,13 +88,13 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
     let(:light) { Stoplight::Light.new(name, &code) }
     let(:name) { ('a'..'z').to_a.shuffle.join }
     let(:code) { -> {} }
-    let(:notifier) { described_class.new(nil, $host, $prefix) }
+    let(:notifier) { described_class.new(nil, host, prefix) }
 
     it 'returns 0 for a working stoplight' do
       expect(notifier.get_status(light.color)).to eql(0)
     end
 
-    context "after the stoplight is red" do
+    context 'after the stoplight is red' do
       let(:light) { Stoplight::Light.new(name, &code).with_threshold(0) }
       let(:code) { -> { 0/0 } }
       it 'returns 2 for a broken stoplight' do
@@ -105,7 +109,7 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
     let(:code) { -> {} }
     let(:from_color) { Stoplight::Color::GREEN }
     let(:to_color) { Stoplight::Color::RED }
-    let(:notifier) { described_class.new(dogapi, $host, $prefix) }
+    let(:notifier) { described_class.new(dogapi, host, prefix) }
     let(:dogapi) { double(Dogapi::Client) }
     let(:api_key) { ('a'..'z').to_a.shuffle.join }
 

--- a/spec/stoplight/notifier/data_dog_service_check_spec.rb
+++ b/spec/stoplight/notifier/data_dog_service_check_spec.rb
@@ -1,0 +1,128 @@
+# coding: utf-8
+
+require 'spec_helper'
+
+# require 'dogapi'
+module Dogapi
+  class Client
+    def initialize(*)
+    end
+  end
+end
+
+RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
+  $prefix = 'stoplight'
+  $host = 'myhostname'
+  it 'is a class' do
+    expect(described_class).to be_a(Class)
+  end
+
+  it 'is a subclass of Base' do
+    expect(described_class).to be < Stoplight::Notifier::Base
+  end
+
+  describe '#formatter' do
+    it 'is initially the default' do
+      expect(described_class.new(nil, $host, $prefix).formatter).to eql(
+        Stoplight::Default::FORMATTER
+      )
+    end
+
+    it 'reads the formatter' do
+      formatter = proc {}
+      expect(described_class.new(nil, $host, $prefix, formatter).formatter).to eql(formatter)
+    end
+  end
+
+  describe '#options' do
+    it 'is intiially the default' do
+      expect(described_class.new(nil, $host, $prefix).options).to eql(
+        Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS
+      )
+    end
+
+    it 'reads the options' do
+      options = { key: :value }
+      expect(described_class.new(nil, $host, $prefix, nil, options).options).to eql(
+        Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS.merge(options)
+      )
+    end
+  end
+
+  describe '#dogapi' do
+    it 'reads the Dogapi client' do
+      dogapi = Dogapi::Client.new('API token')
+      expect(described_class.new(dogapi, $host, $prefix).dogapi)
+        .to eql(dogapi)
+    end
+  end
+
+  describe '#host' do
+    it 'reads the host' do
+      expect(described_class.new(nil, $host, $prefix).host).to eql($host)
+    end
+  end
+
+  describe '#prefix' do
+    it 'reads the prefix' do
+      expect(described_class.new(nil, $host, $prefix).prefix).to eql($prefix)
+    end
+  end
+
+  describe '#check' do
+    let(:light) { Stoplight::Light.new(name, &code) }
+    let(:name) { ('a'..'z').to_a.shuffle.join }
+    let(:code) { -> {} }
+    let(:notifier) { described_class.new(nil, $host, $prefix) }
+
+    it 'returns the prefix combined with the stoplight name' do
+      expect(notifier.check(light)).to eql($prefix + '.' + name)
+    end
+  end
+
+  describe '#get_status' do
+    let(:light) { Stoplight::Light.new(name, &code) }
+    let(:name) { ('a'..'z').to_a.shuffle.join }
+    let(:code) { -> {} }
+    let(:notifier) { described_class.new(nil, $host, $prefix) }
+
+    it 'returns 0 for a working stoplight' do
+      expect(notifier.get_status(light.color)).to eql(0)
+    end
+
+    context "after the stoplight is red" do
+      let(:light) { Stoplight::Light.new(name, &code).with_threshold(0) }
+      let(:code) { -> { 0/0 } }
+      it 'returns 2 for a broken stoplight' do
+        expect(notifier.get_status(light.color)).to eql(2)
+      end
+    end
+  end
+
+  describe '#notify' do
+    let(:light) { Stoplight::Light.new(name, &code) }
+    let(:name) { ('a'..'z').to_a.shuffle.join }
+    let(:code) { -> {} }
+    let(:from_color) { Stoplight::Color::GREEN }
+    let(:to_color) { Stoplight::Color::RED }
+    let(:notifier) { described_class.new(dogapi, $host, $prefix) }
+    let(:dogapi) { double(Dogapi::Client) }
+    let(:api_key) { ('a'..'z').to_a.shuffle.join }
+
+    before do
+      allow(dogapi).to receive(:service_check)
+    end
+
+    it 'returns the message' do
+      error = nil
+      expect(notifier.notify(light, from_color, to_color, error))
+        .to eql(notifier.formatter.call(light, from_color, to_color, error))
+    end
+
+    it 'returns the message with an error' do
+      error = ZeroDivisionError.new('divide by 0')
+      expect(notifier.notify(light, from_color, to_color, error))
+        .to eql(notifier.formatter.call(light, from_color, to_color, error))
+    end
+  end
+end

--- a/spec/stoplight/notifier/data_dog_service_check_spec.rb
+++ b/spec/stoplight/notifier/data_dog_service_check_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
 
     context 'after the stoplight is red' do
       let(:light) { Stoplight::Light.new(name, &code).with_threshold(0) }
-      let(:code) { -> { 0/0 } }
+      let(:code) { -> { 0 / 0 } }
       it 'returns 2 for a broken stoplight' do
         expect(notifier.get_status(light.color)).to eql(2)
       end

--- a/spec/stoplight/notifier/data_dog_service_check_spec.rb
+++ b/spec/stoplight/notifier/data_dog_service_check_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Stoplight::Notifier::DataDogServiceCheck do
       expect(described_class
         .new(nil, host, prefix, nil, options).options)
         .to eql(
-          Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS.merge(options)
+          Stoplight::Notifier::DataDogServiceCheck::DEFAULT_OPTIONS
+          .merge(options)
         )
     end
   end

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |gem|
     'fakeredis' => '0.5',
     'hipchat' => '1.5',
     'honeybadger' => '2.5',
+    'dogapi' => '1.25.0',
     'sentry-raven' => '1.2',
     'rake' => '11.1',
     'redis' => '3.2',


### PR DESCRIPTION
Added a notifier for DataDog service_check functionality to allow for passing working/not working status to DataDog.

DataDog requires a continuous check-in no longer than a minute apart.  This notifier will help with immediate response to DataDog, however, it will not keep the data from going stale.

- Requires the `dogapi` gem