### PR TITLE
Replace concurrent-ruby with MonitorMixin

### DIFF
--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -1,62 +1,53 @@
 # coding: utf-8
 
-require 'concurrent'
+require 'monitor'
 
 module Stoplight
   module DataStore
     # @see Base
     class Memory < Base
+      include MonitorMixin
+
       def initialize
-        @failures = Concurrent::Map.new { [] }
-        @states = Concurrent::Map.new { State::UNLOCKED }
-        @lock = Monitor.new
+        @failures = Hash.new { |h, k| h[k] = [] }
+        @states = Hash.new { |h, k| h[k] = State::UNLOCKED }
+        super() # MonitorMixin
       end
 
       def names
-        (all_failures.keys + all_states.keys).uniq
+        synchronize { @failures.keys | @states.keys }
       end
 
       def get_all(light)
-        [get_failures(light), get_state(light)]
+        synchronize { [@failures[light.name], @states[light.name]] }
       end
 
       def get_failures(light)
-        all_failures[light.name]
+        synchronize { @failures[light.name] }
       end
 
       def record_failure(light, failure)
-        @lock.synchronize do
+        synchronize do
           n = light.threshold - 1
-          failures = get_failures(light).first(n).unshift(failure)
-          all_failures[light.name] = failures
-          failures.size
+          @failures[light.name] = @failures[light.name].first(n)
+          @failures[light.name].unshift(failure).size
         end
       end
 
       def clear_failures(light)
-        all_failures.delete(light.name)
+        synchronize { @failures.delete(light.name) }
       end
 
       def get_state(light)
-        all_states[light.name]
+        synchronize { @states[light.name] }
       end
 
       def set_state(light, state)
-        all_states[light.name] = state
+        synchronize { @states[light.name] = state }
       end
 
       def clear_state(light)
-        all_states.delete(light.name)
-      end
-
-      private
-
-      def all_failures
-        @failures
-      end
-
-      def all_states
-        @states
+        synchronize { @states.delete(light.name) }
       end
     end
   end

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -32,12 +32,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1'
 
   {
-    'concurrent-ruby' => '1.0'
-  }.each do |name, version|
-    gem.add_dependency(name, "~> #{version}")
-  end
-
-  {
     'benchmark-ips' => '2.3',
     'bugsnag' => '4.0',
     'coveralls' => '0.8',


### PR DESCRIPTION
`concurrent-ruby` isn't needed just to do thread safe hashes. Prompted by this memory profile where including the gem is adding almost `6MB` at startup:

```
stoplight: 5.8203 MiB
    stoplight/data_store/memory: 5.293 MiB
      concurrent: 5.2383 MiB
        concurrent/executors: 1.3906 MiB
          concurrent/executor/timer_set: 0.6953 MiB
            concurrent/scheduled_task: 0.4844 MiB (Also required by: concurrent, concurrent/timer_task)
              concurrent/ivar: 0.3047 MiB (Also required by: concurrent/async, concurrent/future, and 2 others)
        concurrent/configuration: 1.3203 MiB (Also required by: concurrent/scheduled_task, concurrent/options, and 2 others)
          concurrent/delay: 0.8789 MiB (Also required by: concurrent/utility/processor_counter, concurrent)
            concurrent/concern/obligation: 0.7031 MiB (Also required by: concurrent/ivar)
              concurrent/atomic/event: 0.6094 MiB (Also required by: concurrent/executor/immediate_executor, concurrent/atomics, and 3 others)
                concurrent/synchronization: 0.5703 MiB (Also required by: concurrent/executor/abstract_executor_service, concurrent/utility/at_exit, and 29 others)
        concurrent/atomics: 0.7422 MiB (Also required by: concurrent/executor/simple_executor_service)
```