### PR TITLE
Support light names containing colons

### DIFF
--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -16,8 +16,9 @@ module Stoplight
         state_names = @redis.hkeys(states_key)
 
         pattern = key('failures', '*')
+        prefix_regex = /^#{key('failures', '')}/
         failure_names = @redis.scan_each(match: pattern).to_a.map do |key|
-          key.split(KEY_SEPARATOR).last
+          key.sub(prefix_regex, '')
         end
 
         (state_names + failure_names).uniq

--- a/spec/stoplight/data_store/memory_spec.rb
+++ b/spec/stoplight/data_store/memory_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe Stoplight::DataStore::Memory do
       data_store.set_state(light, Stoplight::State::UNLOCKED)
       expect(data_store.names).to eql([light.name])
     end
+
+    it 'supports names containing colons' do
+      light = Stoplight::Light.new('http://api.example.com/some/action')
+      data_store.record_failure(light, failure)
+      expect(data_store.names).to eql([light.name])
+    end
   end
 
   describe '#get_all' do

--- a/spec/stoplight/data_store/redis_spec.rb
+++ b/spec/stoplight/data_store/redis_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe Stoplight::DataStore::Redis do
       data_store.set_state(light, Stoplight::State::UNLOCKED)
       expect(data_store.names).to eql([light.name])
     end
+
+    it 'supports names containing colons' do
+      light = Stoplight::Light.new('http://api.example.com/some/action')
+      data_store.record_failure(light, failure)
+      expect(data_store.names).to eql([light.name])
+    end
   end
 
   describe '#get_all' do


### PR DESCRIPTION
Light names containing colons lead to names returned by `data_store.names` to be incomplete
eg. `Stoplight('http://api.example.com/some/action')` and `names` will return `['//api.example.com/some/action']`. 

This leads to a misleading representation of the current state on [stoplight-admin](https://github.com/orgsync/stoplight-admin/blob/master/lib/sinatra/stoplight_admin.rb#L24).