### PR TITLE
Replace Fixnum with Integer in default_spec.rb to eliminate deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ cache: bundler
 language: ruby
 matrix:
   include:
-  - env: RAKE_TASK=rubocop
-    rvm: '2.3.0'
+    - env: RAKE_TASK=rubocop
+      rvm: '2.3.0'
 rvm:
-- '2.3.0'
-- '2.2'
-- '2.1'
+  - '2.5'
+  - '2.4'
+  - '2.3.0'
+  - '2.2'
+  - '2.1'
 script: bundle exec rake $RAKE_TASK
 sudo: false

--- a/spec/stoplight/default_spec.rb
+++ b/spec/stoplight/default_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Stoplight::Default do
 
   describe '::THRESHOLD' do
     it 'is an integer' do
-      expect(Stoplight::Default::THRESHOLD).to be_a(Fixnum)
+      expect(Stoplight::Default::THRESHOLD).to be_a(Integer)
     end
   end
 end


### PR DESCRIPTION
Replacing Fixnum with Integer removes a deprecation warning that you would receive with MRI versions 2.4 and 2.5 respectively but also works fine for 2.1-2.3 versions so I consider this a safe improvement.
I also added 2.4 and 2.5 to the build matrix for travis ci. Also added some indentation to the .travis.yml file where my editor felt that it was in order to do so.