### PR TITLE
Add 15% jitter to circuit breaker recovery timing

### DIFF
--- a/features/stoplight/state_transitions.feature
+++ b/features/stoplight/state_transitions.feature
@@ -22,7 +22,7 @@ Feature: Stoplight State Transitions
   Scenario: Light transitions to yellow after cool-off period
     Given the protected service starts failing with "connection-timeout"
     And the light enters the red state
-    When 61 seconds elapsed
+    When 69 seconds elapsed
     Then the light color is yellow
 
   Scenario: Light transitions to green after success in yellow state

--- a/features/stoplight/step_definitions/circuit_breaker_steps.rb
+++ b/features/stoplight/step_definitions/circuit_breaker_steps.rb
@@ -19,7 +19,7 @@ end
 
 Given(/^(?:the light) enters (?:the )?yellow state$/) do
   step("the light enters the red state")
-  Timecop.travel(Time.now + 1) until current_light.color == Stoplight::Color::YELLOW
+  Timecop.travel(Time.now + current_light.config.cool_off_time * 1.5) until current_light.color == Stoplight::Color::YELLOW
 
   expect(current_light.color).to eq(Stoplight::Color::YELLOW)
 end

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -17,12 +17,22 @@ module Stoplight
     #   @return [String]
     def_delegator :config, :name
 
+    # @!attribute [r] jitter
+    #   @return [Numeric] a random jitter to add to the cool-off time
+    private attr_reader :jitter
+
+    JITTER_FACTOR = 0.15
+    private_constant :JITTER_FACTOR
+
     # @param config [Stoplight::Light::Config]
     def initialize(config, green_run_strategy: nil, yellow_run_strategy: nil, red_run_strategy: nil)
       @config = config
       @green_run_strategy = green_run_strategy
       @yellow_run_strategy = yellow_run_strategy
       @red_run_strategy = red_run_strategy
+      @jitter = (config.cool_off_time * JITTER_FACTOR).then do |jitter_size|
+        rand(-jitter_size..jitter_size)
+      end
     end
 
     # Returns the current state of the light:
@@ -52,7 +62,7 @@ module Stoplight
       config
         .data_store
         .get_metadata(config)
-        .color
+        .color(jitter:)
     end
 
     # Runs the given block of code with this circuit breaker

--- a/lib/stoplight/light/yellow_run_strategy.rb
+++ b/lib/stoplight/light/yellow_run_strategy.rb
@@ -17,7 +17,6 @@ module Stoplight
       # @return [Object] The result of the code block if successful.
       # @raise [Exception] Re-raises the error if it is not tracked or no fallback is provided.
       def execute(fallback, &code)
-        # TODO: We need to employ a probabilistic approach here to avoid "thundering herd" problem
         code.call.tap { record_recovery_probe_success }
       rescue => error
         if config.track_error?(error)

--- a/lib/stoplight/metadata.rb
+++ b/lib/stoplight/metadata.rb
@@ -53,13 +53,14 @@ module Stoplight
     end
 
     # @param at [Time] (Time.now) the moment of time when the color is determined
+    # @param jitter [Numeric] a recovery jitter factor in seconds
     # @return [String] one of +Color::GREEN+, +Color::RED+, or +Color::YELLOW+
-    def color(at: Time.now)
+    def color(jitter:, at: Time.now)
       if locked_state == State::LOCKED_GREEN
         Color::GREEN
       elsif locked_state == State::LOCKED_RED
         Color::RED
-      elsif (recovery_scheduled_after && recovery_scheduled_after < at) || recovery_started_at
+      elsif (recovery_scheduled_after && recovery_scheduled_after + jitter < at) || recovery_started_at
         Color::YELLOW
       elsif breached_at
         Color::RED

--- a/spec/stoplight/metadata_spec.rb
+++ b/spec/stoplight/metadata_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Stoplight::Metadata do
   describe "#color" do
-    subject(:color) { metadata.color(at: current_time) }
+    subject(:color) { metadata.color(at: current_time, jitter:) }
 
     let(:metadata) do
       Stoplight::Metadata.new(
@@ -14,6 +12,7 @@ RSpec.describe Stoplight::Metadata do
         breached_at:
       )
     end
+    let(:jitter) { 10 }
     let(:current_time) { Time.now }
     let(:recovery_scheduled_after) { nil }
     let(:locked_state) { nil }
@@ -35,7 +34,7 @@ RSpec.describe Stoplight::Metadata do
     end
 
     context "when recovery scheduled before current time" do
-      let(:recovery_scheduled_after) { current_time - 1 }
+      let(:recovery_scheduled_after) { current_time - jitter - 1 }
 
       it { is_expected.to be(Stoplight::Color::YELLOW) }
     end


### PR DESCRIPTION
#366 

Multiple circuit breaker instances transitioning from RED to YELLOW state simultaneously create a thundering herd, causing coordinated load spikes on recovering services.

This PR adds bidirectional random jitter (±15% of cool-off time) to recovery timing, distributing the RED→YELLOW transitions across time.

Example:

```
# cool_off_time = 60 seconds
# jitter range = ±9 seconds (15%)
# Instance A: recovers at 51 seconds  
# Instance B: recovers at 67 seconds
# Instance C: recovers at 58 seconds
```

## Discussion Point

While this solves the initial thundering herd, a secondary coordination issue remains: once any instance enters YELLOW state and sets `recovery_started_at`, all subsequent instances immediately enter YELLOW without jitter, potentially creating coordinated probe attempts.

## How can we solve this?

We can move the coordination logic from state determination into `YellowRunStrategy` to control individual probe decisions:

* Current: Binary state (YELLOW = probe immediately)
* Proposed: Granular coordination (YELLOW = eligible to probe, strategy decides when)

This would provide finer control over recovery coordination while maintaining clean state semantics.

## Questions:

* Should we implement probabilistic probing in YellowRunStrategy?
* Is Redis-based probe coordination worth the complexity?
* Should the coordination strategy be configurable per circuit or be hardcoded as a default?