### PR TITLE
feat: Introduce public config

### DIFF
--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -5,6 +5,14 @@ module Stoplight
     Base = Class.new(StandardError)
     ConfigurationError = Class.new(Base)
     IncorrectColor = Class.new(Base)
-    RedLight = Class.new(Base)
+
+    class RedLight < Base
+      attr_reader :config
+
+      def initialize(message, public_config)
+        @config = public_config
+        super(message)
+      end
+    end
   end
 end

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -12,6 +12,10 @@ module Stoplight
     #   @api private
     attr_reader :config
 
+    # @!attribute [r] public_config
+    #   @return [Stoplight::Light::PublicConfig]
+    attr_reader :public_config
+
     # @!attribute [r] name
     #   The name of the light.
     #   @return [String]
@@ -20,6 +24,7 @@ module Stoplight
     # @param config [Stoplight::Light::Config]
     def initialize(config, green_run_strategy: nil, yellow_run_strategy: nil, red_run_strategy: nil)
       @config = config
+      @public_config = Stoplight::Light::PublicConfig.new(config)
       @green_run_strategy = green_run_strategy
       @yellow_run_strategy = yellow_run_strategy
       @red_run_strategy = red_run_strategy

--- a/lib/stoplight/light/public_config.rb
+++ b/lib/stoplight/light/public_config.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Stoplight
+  class Light
+    class PublicConfig
+      # @!attribute [r] config
+      #   @return [Stoplight::Light::Config]
+      #   @api private
+      private attr_reader :config
+
+      def initialize(config)
+        @config = config
+      end
+
+      def recovery_stage_starts_at
+        recovery_scheduled_after = config.data_store.get_metadata(config).recovery_scheduled_after
+        current_time = Time.now
+
+        (recovery_scheduled_after > current_time) ? current_time : current_time + recovery_scheduled_after
+      end
+    end
+  end
+end

--- a/lib/stoplight/light/red_run_strategy.rb
+++ b/lib/stoplight/light/red_run_strategy.rb
@@ -19,7 +19,7 @@ module Stoplight
         if fallback
           fallback.call(nil)
         else
-          raise Error::RedLight, config.name
+          raise Error::RedLight.new config.name, public_config
         end
       end
     end

--- a/lib/stoplight/light/run_strategy.rb
+++ b/lib/stoplight/light/run_strategy.rb
@@ -12,6 +12,10 @@ module Stoplight
       #   @return [Stoplight::Light::Config] The configuration for the light.
       private attr_reader :config
 
+      # @!attribute [r] public_config
+      #   @return [Stoplight::Light::PublicConfig] The configuration for the light.
+      private attr_reader :public_config
+
       # @!attribute [r] data_store
       #   @return [Stoplight::DataStore::Base] The data store associated with the light.
       private attr_reader :data_store
@@ -19,6 +23,7 @@ module Stoplight
       # @param config [Stoplight::Light::Config] The configuration for the light.
       def initialize(config)
         @config = config
+        @public_config = Stoplight::Light::PublicConfig.new(config)
         @data_store = config.data_store
       end
 


### PR DESCRIPTION
This PR aims to introduce public config, which will be exposed when users need to access additional information from our Lights.

We need it since we want to avoid direct access to our [Stoplight::Light::Config](https://github.com/bolshakov/stoplight/blob/8c7208dd5f060bab7840c1769370376ede333e82/lib/stoplight/light/config.rb), since it will prevent us from easily changing Stoplight internals.

For now, we expose only the Time when the Light turns Yellow. We will provide more info in the public config in the future.