### PR TITLE
Timestamp metrics at recording time, not event time

### DIFF
--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -30,10 +30,10 @@ module Stoplight
       # @return [Stoplight::Metadata]
       def get_metadata(config)
         light_name = config.name
+        current_time = self.current_time
+        recovery_window = (current_time - config.cool_off_time)..current_time
 
         synchronize do
-          current_time = Time.now
-          recovery_window = (current_time - config.cool_off_time)..current_time
           recovered_at = @metadata[light_name].recovered_at
           window = if config.window_size
             window_start = [recovered_at, (current_time - config.window_size)].compact.max
@@ -71,7 +71,7 @@ module Stoplight
       # @param window_size [Numeric, nil]
       # @return [void]
       def cleanup(metrics, window_size:)
-        min_age = Time.now - [window_size&.*(3), METRICS_RETENTION_TIME].compact.min
+        min_age = current_time - [window_size&.*(3), METRICS_RETENTION_TIME].compact.min
 
         metrics.reject! { _1 < min_age }
       end
@@ -80,17 +80,18 @@ module Stoplight
       # @param failure [Stoplight::Failure]
       # @return [Stoplight::Metadata]
       def record_failure(config, failure)
+        current_time = self.current_time
         light_name = config.name
 
         synchronize do
-          @errors[light_name].unshift(failure.time) if config.window_size
+          @errors[light_name].unshift(current_time) if config.window_size
 
           cleanup(@errors[light_name], window_size: config.window_size)
 
           metadata = @metadata[light_name]
-          @metadata[light_name] = if metadata.last_error_at.nil? || failure.time > metadata.last_error_at
+          @metadata[light_name] = if metadata.last_error_at.nil? || current_time > metadata.last_error_at
             metadata.with(
-              last_error_at: failure.time,
+              last_error_at: current_time,
               last_error: failure,
               consecutive_errors: metadata.consecutive_errors.succ,
               consecutive_successes: 0
@@ -106,20 +107,19 @@ module Stoplight
       end
 
       # @param config [Stoplight::Light::Config]
-      # @param request_id [String]
-      # @param request_time [Time]
       # @return [void]
-      def record_success(config, request_time: Time.now, request_id: SecureRandom.hex(12))
+      def record_success(config)
         light_name = config.name
+        current_time = self.current_time
 
         synchronize do
-          @successes[light_name].unshift(request_time) if config.window_size
+          @successes[light_name].unshift(current_time) if config.window_size
           cleanup(@successes[light_name], window_size: config.window_size)
 
           metadata = @metadata[light_name]
-          @metadata[light_name] = if metadata.last_success_at.nil? || request_time > metadata.last_success_at
+          @metadata[light_name] = if metadata.last_success_at.nil? || current_time > metadata.last_success_at
             metadata.with(
-              last_success_at: request_time,
+              last_success_at: current_time,
               consecutive_errors: 0,
               consecutive_successes: metadata.consecutive_successes.succ
             )
@@ -137,15 +137,16 @@ module Stoplight
       # @return [Stoplight::Metadata]
       def record_recovery_probe_failure(config, failure)
         light_name = config.name
+        current_time = self.current_time
 
         synchronize do
-          @recovery_probe_errors[light_name].unshift(failure.time)
+          @recovery_probe_errors[light_name].unshift(current_time)
           cleanup(@recovery_probe_errors[light_name], window_size: config.cool_off_time)
 
           metadata = @metadata[light_name]
-          @metadata[light_name] = if metadata.last_error_at.nil? || failure.time > metadata.last_error_at
+          @metadata[light_name] = if metadata.last_error_at.nil? || current_time > metadata.last_error_at
             metadata.with(
-              last_error_at: failure.time,
+              last_error_at: current_time,
               last_error: failure,
               consecutive_errors: metadata.consecutive_errors.succ,
               consecutive_successes: 0
@@ -161,20 +162,19 @@ module Stoplight
       end
 
       # @param config [Stoplight::Light::Config]
-      # @param request_id [String]
-      # @param request_time [Time]
       # @return [Stoplight::Metadata]
-      def record_recovery_probe_success(config, request_time: Time.now, request_id: SecureRandom.hex(12))
+      def record_recovery_probe_success(config)
         light_name = config.name
+        current_time = self.current_time
 
         synchronize do
-          @recovery_probe_successes[light_name].unshift(request_time)
+          @recovery_probe_successes[light_name].unshift(current_time)
           cleanup(@recovery_probe_successes[light_name], window_size: config.cool_off_time)
 
           metadata = @metadata[light_name]
-          @metadata[light_name] = if metadata.last_success_at.nil? || request_time > metadata.last_success_at
+          @metadata[light_name] = if metadata.last_success_at.nil? || current_time > metadata.last_success_at
             metadata.with(
-              last_success_at: request_time,
+              last_success_at: current_time,
               consecutive_errors: 0,
               consecutive_successes: metadata.consecutive_successes.succ
             )
@@ -210,16 +210,15 @@ module Stoplight
       #
       # @param config [Stoplight::Light::Config] The light configuration
       # @param color [String] The color to transition to ("GREEN", "YELLOW", or "RED")
-      # @param current_time [Time]
       # @return [Boolean] true if this is the first instance to detect this transition
-      def transition_to_color(config, color, current_time: Time.now)
+      def transition_to_color(config, color)
         case color
         when Color::GREEN
           transition_to_green(config)
         when Color::YELLOW
-          transition_to_yellow(config, current_time:)
+          transition_to_yellow(config)
         when Color::RED
-          transition_to_red(config, current_time:)
+          transition_to_red(config)
         else
           raise ArgumentError, "Invalid color: #{color}"
         end
@@ -229,8 +228,9 @@ module Stoplight
       #
       # @param config [Stoplight::Light::Config] The light configuration
       # @return [Boolean] true if this is the first instance to detect this transition
-      private def transition_to_green(config, current_time: Time.now)
+      private def transition_to_green(config)
         light_name = config.name
+        current_time = self.current_time
 
         synchronize do
           metadata = @metadata[light_name]
@@ -251,10 +251,10 @@ module Stoplight
       # Transitions to YELLOW (recovery) state and ensures only one notification
       #
       # @param config [Stoplight::Light::Config] The light configuration
-      # @param current_time [Time]
       # @return [Boolean] true if this is the first instance to detect this transition
-      private def transition_to_yellow(config, current_time: Time.now)
+      private def transition_to_yellow(config)
         light_name = config.name
+        current_time = self.current_time
 
         synchronize do
           metadata = @metadata[light_name]
@@ -280,10 +280,10 @@ module Stoplight
       # Transitions to RED state and ensures only one notification
       #
       # @param config [Stoplight::Light::Config] The light configuration
-      # @param current_time [Time]
       # @return [Boolean] true if this is the first instance to detect this transition
-      private def transition_to_red(config, current_time: Time.now)
+      private def transition_to_red(config)
         light_name = config.name
+        current_time = self.current_time
         recovery_scheduled_after = current_time + config.cool_off_time
 
         synchronize do
@@ -305,6 +305,10 @@ module Stoplight
             true
           end
         end
+      end
+
+      private def current_time
+        Time.now
       end
     end
   end

--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -94,7 +94,6 @@ module Stoplight
       def get_metadata(config)
         detect_clock_skew
 
-        current_time = Time.now
         window_end_ts = current_time.to_i
         window_start_ts = window_end_ts - [config.window_size, Base::METRICS_RETENTION_TIME].compact.min.to_i
         recovery_window_start_ts = window_end_ts - config.cool_off_time.to_i
@@ -147,7 +146,7 @@ module Stoplight
       # @param failure [Stoplight::Failure] The failure to record.
       # @return [Stoplight::Metadata] The updated metadata after recording the failure.
       def record_failure(config, failure)
-        current_ts = failure.time.to_i
+        current_ts = current_time.to_i
         failure_json = failure.to_json
 
         @redis.then do |client|
@@ -163,16 +162,16 @@ module Stoplight
         get_metadata(config)
       end
 
-      def record_success(config, request_id: SecureRandom.hex(12), request_time: Time.now)
-        request_ts = request_time.to_i
+      def record_success(config, request_id: SecureRandom.hex(12))
+        current_ts = current_time.to_i
 
         @redis.then do |client|
           client.evalsha(
             record_success_sha,
-            argv: [request_ts, request_id, metrics_ttl, metadata_ttl],
+            argv: [current_ts, request_id, metrics_ttl, metadata_ttl],
             keys: [
               metadata_key(config),
-              config.window_size && successes_key(config, time: request_ts)
+              config.window_size && successes_key(config, time: current_ts)
             ].compact
           )
         end
@@ -184,7 +183,7 @@ module Stoplight
       # @param failure [Failure] The failure to record.
       # @return [Stoplight::Metadata] The updated metadata after recording the failure.
       def record_recovery_probe_failure(config, failure)
-        current_ts = failure.time.to_i
+        current_ts = current_time.to_i
         failure_json = failure.to_json
 
         @redis.then do |client|
@@ -204,18 +203,17 @@ module Stoplight
       #
       # @param config [Stoplight::Light::Config] The light configuration.
       # @param request_id [String] The unique identifier for the request
-      # @param request_time [Time] The time of the request
       # @return [Stoplight::Metadata] The updated metadata after recording the success.
-      def record_recovery_probe_success(config, request_id: SecureRandom.hex(12), request_time: Time.now)
-        request_ts = request_time.to_i
+      def record_recovery_probe_success(config, request_id: SecureRandom.hex(12))
+        current_ts = current_time.to_i
 
         @redis.then do |client|
           client.evalsha(
             record_success_sha,
-            argv: [request_ts, request_id, metrics_ttl, metadata_ttl],
+            argv: [current_ts, request_id, metrics_ttl, metadata_ttl],
             keys: [
               metadata_key(config),
-              recovery_probe_successes_key(config, time: request_ts)
+              recovery_probe_successes_key(config, time: current_ts)
             ].compact
           )
         end
@@ -237,18 +235,15 @@ module Stoplight
       #
       # @param config [Stoplight::Light::Config] The light configuration
       # @param color [String] The color to transition to ("green", "yellow", or "red")
-      # @param current_time [Time] Current timestamp
       # @return [Boolean] true if this is the first instance to detect this transition
-      def transition_to_color(config, color, current_time: Time.now)
-        current_time.to_i
-
+      def transition_to_color(config, color)
         case color
         when Color::GREEN
           transition_to_green(config)
         when Color::YELLOW
-          transition_to_yellow(config, current_time:)
+          transition_to_yellow(config)
         when Color::RED
-          transition_to_red(config, current_time:)
+          transition_to_red(config)
         else
           raise ArgumentError, "Invalid color: #{color}"
         end
@@ -258,7 +253,7 @@ module Stoplight
       #
       # @param config [Stoplight::Light::Config] The light configuration
       # @return [Boolean] true if this is the first instance to detect this transition
-      private def transition_to_green(config, current_time: Time.now)
+      private def transition_to_green(config)
         current_ts = current_time.to_i
         meta_key = metadata_key(config)
 
@@ -275,9 +270,8 @@ module Stoplight
       # Transitions to YELLOW (recovery) state and ensures only one notification
       #
       # @param config [Stoplight::Light::Config] The light configuration
-      # @param current_time [Time] Current timestamp
       # @return [Boolean] true if this is the first instance to detect this transition
-      private def transition_to_yellow(config, current_time: Time.now)
+      private def transition_to_yellow(config)
         current_ts = current_time.to_i
         meta_key = metadata_key(config)
 
@@ -294,9 +288,8 @@ module Stoplight
       # Transitions to RED state and ensures only one notification
       #
       # @param config [Stoplight::Light::Config] The light configuration
-      # @param current_time [Time] Current timestamp
       # @return [Boolean] true if this is the first instance to detect this transition
-      private def transition_to_red(config, current_time: Time.now)
+      private def transition_to_red(config)
         current_ts = current_time.to_i
         meta_key = metadata_key(config)
         recovery_scheduled_after_ts = current_ts + config.cool_off_time
@@ -399,7 +392,7 @@ module Stoplight
         return unless should_sample?(0.01) # 1% chance
 
         redis_seconds, _redis_millis = @redis.then(&:time)
-        app_seconds = Time.now.to_i
+        app_seconds = current_time.to_i
         if (redis_seconds - app_seconds).abs > SKEW_TOLERANCE
           warn("Detected clock skew between Redis and the application server. Redis time: #{redis_seconds}, Application time: #{app_seconds}. See https://github.com/bolshakov/stoplight/wiki/Clock-Skew-and-Stoplight-Reliability")
         end
@@ -443,6 +436,10 @@ module Stoplight
         @record_failure_sha ||= @redis.then do |client|
           client.script("load", Lua::RECORD_FAILURE)
         end
+      end
+
+      private def current_time
+        Time.now
       end
     end
   end

--- a/spec/support/data_store/base/metrics.rb
+++ b/spec/support/data_store/base/metrics.rb
@@ -4,10 +4,16 @@ RSpec.shared_examples "data store metrics" do
   describe "Metadata#last_success_at" do
     let(:request_time) { Time.at(1746119141) }
 
+    around do |example|
+      Timecop.freeze(request_time) do
+        example.run
+      end
+    end
+
     context "when the success is recorded" do
       it "returns the time of the success" do
         expect do
-          data_store.record_success(config, request_time:)
+          data_store.record_success(config)
         end.to change { data_store.get_metadata(config).last_success_at }
           .from(nil)
           .to(request_time)
@@ -17,54 +23,41 @@ RSpec.shared_examples "data store metrics" do
     context "when the recovery probe success is recorded" do
       it "returns the time of the success" do
         expect do
-          data_store.record_recovery_probe_success(config, request_time:)
+          data_store.record_recovery_probe_success(config)
         end.to change { data_store.get_metadata(config).last_success_at }
           .from(nil)
           .to(request_time)
       end
     end
 
-    context "when an older request is recorded after a newer one" do
-      let(:older_request_time) { Time.at(1746110141) }
-
-      before do
-        data_store.record_success(config, request_time:)
-      end
-
-      it "returns the time of the latest successful request" do
-        expect do
-          data_store.record_success(config, request_time: older_request_time)
-        end.not_to change { data_store.get_metadata(config).last_success_at }
-          .from(request_time)
-      end
-    end
-
     context "when a newer request is recorded after an older one" do
-      let(:older_request_time) { Time.at(1746110141) }
-
       before do
-        data_store.record_success(config, request_time: older_request_time)
+        data_store.record_success(config)
       end
 
       it "returns the time of the latest request" do
         expect do
-          data_store.record_success(config, request_time:)
+          Timecop.freeze(request_time + 20) do
+            data_store.record_success(config)
+          end
         end.to change { data_store.get_metadata(config).last_success_at }
-          .from(older_request_time)
-          .to(request_time)
+          .from(request_time)
+          .to(request_time + 20)
       end
     end
 
     context "when a newer recovery probe success is recorded after a normal request" do
-      let(:recovery_probe_request_time) { Time.at(1746159141) }
+      let(:recovery_probe_request_time) { request_time + 20 }
 
       before do
-        data_store.record_success(config, request_time:)
+        data_store.record_success(config)
       end
 
       it "returns the time of the latest request" do
         expect do
-          data_store.record_recovery_probe_success(config, request_time: recovery_probe_request_time)
+          Timecop.freeze(recovery_probe_request_time) do
+            data_store.record_recovery_probe_success(config)
+          end
         end.to change { data_store.get_metadata(config).last_success_at }
           .from(request_time)
           .to(recovery_probe_request_time)
@@ -72,15 +65,17 @@ RSpec.shared_examples "data store metrics" do
     end
 
     context "when a success is recorded after a recovery probe success" do
-      let(:recovery_probe_request_time) { Time.at(1746110141) }
+      let(:recovery_probe_request_time) { request_time - 20 }
 
       before do
-        data_store.record_recovery_probe_success(config, request_time: recovery_probe_request_time)
+        Timecop.freeze(recovery_probe_request_time) do
+          data_store.record_recovery_probe_success(config)
+        end
       end
 
       it "returns the time of the latest request" do
         expect do
-          data_store.record_success(config, request_time:)
+          data_store.record_success(config)
         end.to change { data_store.get_metadata(config).last_success_at }
           .from(recovery_probe_request_time)
           .to(request_time)
@@ -88,40 +83,34 @@ RSpec.shared_examples "data store metrics" do
     end
 
     context "when a newer recovery probe success is recorded after another recovery probe success" do
-      let(:recovery_probe_request_time) { Time.at(1746159141) }
+      let(:recovery_probe_request_time) { request_time + 20 }
 
       before do
-        data_store.record_recovery_probe_success(config, request_time:)
+        data_store.record_recovery_probe_success(config)
       end
 
       it "returns the time of the latest request" do
         expect do
-          data_store.record_recovery_probe_success(config, request_time: recovery_probe_request_time)
+          Timecop.freeze(recovery_probe_request_time) do
+            data_store.record_recovery_probe_success(config)
+          end
         end.to change { data_store.get_metadata(config).last_success_at }
           .from(request_time)
           .to(recovery_probe_request_time)
-      end
-    end
-
-    context "when a newer recovery probe success is recorded after a newer recovery probe success" do
-      let(:recovery_probe_request_time) { request_time - 10 }
-
-      before do
-        data_store.record_recovery_probe_success(config, request_time:)
-      end
-
-      it "returns the time of the latest request" do
-        expect do
-          data_store.record_recovery_probe_success(config, request_time: recovery_probe_request_time)
-        end.not_to change { data_store.get_metadata(config).last_success_at }
-          .from(request_time)
       end
     end
   end
 
   describe "Metadata#last_error_at" do
     let(:failure) { Stoplight::Failure.from_error(error) }
+    let(:request_time) { failure.time }
     let(:error) { StandardError.new("Test error") }
+
+    around do |example|
+      Timecop.freeze(request_time) do
+        example.run
+      end
+    end
 
     context "when the failure is recorded" do
       it "returns the time of the failure" do
@@ -129,43 +118,51 @@ RSpec.shared_examples "data store metrics" do
           data_store.record_failure(config, failure)
         end.to change { data_store.get_metadata(config).last_error_at }
           .from(nil)
-          .to(failure.time)
+          .to(request_time)
       end
     end
 
     context "when an older failure is recorded after a newer one" do
       let(:older_failure) { Stoplight::Failure.from_error(error, time: Time.now - 1000) }
+      let(:older_failure_request_time) { request_time + 20 }
 
       before do
         data_store.record_failure(config, failure)
       end
 
-      it "returns the time of the latest failure" do
+      it "returns the time of the latest recorded failure" do
         expect do
-          data_store.record_failure(config, older_failure)
-        end.not_to change { data_store.get_metadata(config).last_error_at }
-          .from(failure.time)
+          Timecop.freeze(older_failure_request_time) do
+            data_store.record_failure(config, older_failure)
+          end
+        end.to change { data_store.get_metadata(config).last_error_at }
+          .from(request_time)
+          .to(older_failure_request_time)
       end
     end
 
     context "when a newer failure is recorded after an older one" do
       let(:older_failure) { Stoplight::Failure.from_error(error, time: Time.now - 1000) }
+      let(:older_failure_request_time) { request_time - 20 }
 
       before do
-        data_store.record_failure(config, older_failure)
+        Timecop.freeze(older_failure_request_time) do
+          data_store.record_failure(config, older_failure)
+        end
       end
 
       it "returns the time of the latest failure" do
         expect do
           data_store.record_failure(config, failure)
         end.to change { data_store.get_metadata(config).last_error_at }
-          .from(older_failure.time)
-          .to(failure.time)
+          .from(older_failure_request_time)
+          .to(request_time)
       end
     end
 
     context "when a newer recovery probe failure is recorded after a failure" do
       let(:recovery_probe_failure) { Stoplight::Failure.from_error(error, time: Time.now + 5000) }
+      let(:recovery_probe_failure_request_time) { request_time + 5000 }
 
       before do
         data_store.record_failure(config, failure)
@@ -173,26 +170,31 @@ RSpec.shared_examples "data store metrics" do
 
       it "returns the time of the latest failure" do
         expect do
-          data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+          Timecop.freeze(recovery_probe_failure_request_time) do
+            data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+          end
         end.to change { data_store.get_metadata(config).last_error_at }
-          .from(failure.time)
-          .to(recovery_probe_failure.time)
+          .from(request_time)
+          .to(recovery_probe_failure_request_time)
       end
     end
 
     context "when a failure is recorded after a recovery probe failure" do
       let(:recovery_probe_failure) { Stoplight::Failure.from_error(error, time: Time.now - 5000) }
+      let(:recovery_probe_failure_request_time) { request_time - 5000 }
 
       before do
-        data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+        Timecop.freeze(recovery_probe_failure_request_time) do
+          data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+        end
       end
 
       it "returns the time of the latest failure" do
         expect do
           data_store.record_failure(config, failure)
         end.to change { data_store.get_metadata(config).last_error_at }
-          .from(recovery_probe_failure.time)
-          .to(failure.time)
+          .from(recovery_probe_failure_request_time)
+          .to(request_time)
       end
     end
   end
@@ -212,29 +214,35 @@ RSpec.shared_examples "data store metrics" do
     end
 
     context "when an older failure is recorded after a newer one" do
-      let(:older_failure) { Stoplight::Failure.from_error(error, time: Time.now - 5000) }
+      let(:older_failure) { Stoplight::Failure.from_error(older_error, time: Time.now - 5000) }
+      let(:older_error) { StandardError.new("older error") }
 
       before do
         data_store.record_failure(config, failure)
       end
 
-      it "returns the latest failure" do
+      it "returns the latest recorded failure" do
         expect(data_store.get_metadata(config).last_error).to eq(failure)
 
-        data_store.record_failure(config, older_failure)
+        Timecop.freeze(Time.now + 1) do
+          metadata = data_store.record_failure(config, older_failure)
 
-        expect(data_store.get_metadata(config).last_error).to eq(failure)
+          expect(metadata.last_error).to eq(older_failure)
+        end
       end
     end
 
     context "when a newer failure is recorded after an older one" do
       let(:older_failure) { Stoplight::Failure.from_error(error, time: Time.now - 1000) }
+      let(:older_failure_request_time) { older_failure.time }
 
       before do
-        data_store.record_failure(config, older_failure)
+        Timecop.freeze(older_failure_request_time) do
+          data_store.record_failure(config, older_failure)
+        end
       end
 
-      it "returns the time of the latest failure" do
+      it "returns the time of the latest recorded failure" do
         expect(data_store.get_metadata(config).last_error).to eq(older_failure)
 
         data_store.record_failure(config, failure)
@@ -245,15 +253,18 @@ RSpec.shared_examples "data store metrics" do
 
     context "when a newer recovery probe failure is recorded after a failure" do
       let(:recovery_probe_failure) { Stoplight::Failure.from_error(error, time: Time.now + 5000) }
+      let(:recovery_probe_failure_request_time) { recovery_probe_failure.time }
 
       before do
         data_store.record_failure(config, failure)
       end
 
-      it "returns the time of the latest failure" do
+      it "returns the time of the latest recorded failure" do
         expect(data_store.get_metadata(config).last_error).to eq(failure)
 
-        data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+        Timecop.freeze(recovery_probe_failure_request_time) do
+          data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+        end
 
         expect(data_store.get_metadata(config).last_error).to eq(recovery_probe_failure)
       end
@@ -261,12 +272,15 @@ RSpec.shared_examples "data store metrics" do
 
     context "when a failure is recorded after a recovery probe failure" do
       let(:recovery_probe_failure) { Stoplight::Failure.from_error(error, time: Time.now - 5000) }
+      let(:recovery_probe_failure_request_time) { recovery_probe_failure.time }
 
       before do
-        data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+        Timecop.freeze(recovery_probe_failure_request_time) do
+          data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+        end
       end
 
-      it "returns the time of the latest failure" do
+      it "returns the time of the latest recorded failure" do
         expect(data_store.get_metadata(config).last_error).to eq(recovery_probe_failure)
 
         data_store.record_failure(config, failure)
@@ -321,7 +335,9 @@ RSpec.shared_examples "data store metrics" do
         let(:window_size) { 5000 }
 
         it "returns the the number of successful requests within the current window" do
-          data_store.record_success(config, request_time: Time.now - window_size - 1)
+          Timecop.freeze(Time.now - window_size - 1) do
+            data_store.record_success(config)
+          end
           data_store.record_success(config)
           data_store.record_success(config)
 
@@ -377,7 +393,9 @@ RSpec.shared_examples "data store metrics" do
         let(:window_size) { 5000 }
 
         it "returns the the number of successful requests within the current window" do
-          data_store.record_failure(config, outdated_failure)
+          Timecop.freeze(outdated_failure.time) do
+            data_store.record_failure(config, outdated_failure)
+          end
           data_store.record_failure(config, failure)
           data_store.record_failure(config, failure)
 
@@ -420,7 +438,9 @@ RSpec.shared_examples "data store metrics" do
       let(:window_size) { 5000 }
 
       it "returns the the number of successful requests within the current window" do
-        data_store.record_recovery_probe_success(config, request_time: Time.now - window_size - 1)
+        Timecop.freeze(Time.now - window_size - 1) do
+          data_store.record_recovery_probe_success(config)
+        end
         data_store.record_recovery_probe_success(config)
         data_store.record_recovery_probe_success(config)
 
@@ -463,7 +483,9 @@ RSpec.shared_examples "data store metrics" do
       let(:window_size) { 5000 }
 
       it "returns the the number of successful requests within the current window" do
-        data_store.record_recovery_probe_failure(config, outdated_failure)
+        Timecop.freeze(outdated_failure.time) do
+          data_store.record_recovery_probe_failure(config, outdated_failure)
+        end
         data_store.record_recovery_probe_failure(config, failure)
         data_store.record_recovery_probe_failure(config, failure)
 
@@ -504,7 +526,9 @@ RSpec.shared_examples "data store metrics" do
       let(:window_size) { 5000 }
 
       it "returns the the number of successful requests within the current window" do
-        data_store.record_success(config, request_time: Time.now - window_size - 1)
+        Timecop.freeze(Time.now - window_size - 1) do
+          data_store.record_success(config)
+        end
         data_store.record_success(config)
         data_store.record_success(config)
 
@@ -546,7 +570,9 @@ RSpec.shared_examples "data store metrics" do
       let(:window_size) { 5000 }
 
       it "returns the the number of successful requests within the current window" do
-        data_store.record_failure(config, outdated_failure)
+        Timecop.freeze(outdated_failure.time) do
+          data_store.record_failure(config, outdated_failure)
+        end
         data_store.record_failure(config, failure)
         data_store.record_failure(config, failure)
 
@@ -606,7 +632,9 @@ RSpec.shared_examples "data store metrics" do
         let(:window_size) { 300 }
 
         it "returns the the number of successful errors within the current window" do
-          data_store.record_failure(config, outdated_failure)
+          Timecop.freeze(outdated_failure.time) do
+            data_store.record_failure(config, outdated_failure)
+          end
           data_store.record_failure(config, failure)
           data_store.record_failure(config, failure)
 
@@ -623,7 +651,9 @@ RSpec.shared_examples "data store metrics" do
         let(:window_size) { 300 }
 
         it "returns the the number of successful errors within the current window after recovery" do
-          data_store.record_failure(config, outdated_failure)
+          Timecop.freeze(outdated_failure.time) do
+            data_store.record_failure(config, outdated_failure)
+          end
           data_store.transition_to_color(config, Stoplight::Color::RED)
           data_store.transition_to_color(config, Stoplight::Color::GREEN)
 

--- a/spec/support/data_store/base/transition_to_color.rb
+++ b/spec/support/data_store/base/transition_to_color.rb
@@ -20,7 +20,9 @@ RSpec.shared_examples "Stoplight::DataStore::Base#transition_to_color" do
       it { expect(data_store.transition_to_color(config, Stoplight::Color::GREEN)).to be(true) }
 
       it "resets timestamps" do
-        data_store.transition_to_color(config, Stoplight::Color::GREEN, current_time:)
+        Timecop.freeze(current_time) do
+          data_store.transition_to_color(config, Stoplight::Color::GREEN)
+        end
 
         expect(data_store.get_metadata(config)).to have_attributes(
           recovery_started_at: nil,
@@ -49,7 +51,9 @@ RSpec.shared_examples "Stoplight::DataStore::Base#transition_to_color" do
 
       it "sets the recovery_started_at timestamp" do
         expect do
-          data_store.transition_to_color(config, Stoplight::Color::YELLOW, current_time:)
+          Timecop.freeze(current_time) do
+            data_store.transition_to_color(config, Stoplight::Color::YELLOW)
+          end
         end.to change { data_store.get_metadata(config) }
           .from(have_attributes(recovery_started_at: nil))
           .to(have_attributes(recovery_started_at: current_time))
@@ -75,7 +79,9 @@ RSpec.shared_examples "Stoplight::DataStore::Base#transition_to_color" do
 
       it "sets the breached_at and recovery_scheduled_after timestamps" do
         expect do
-          data_store.transition_to_color(config, Stoplight::Color::RED, current_time:)
+          Timecop.freeze(current_time) do
+            data_store.transition_to_color(config, Stoplight::Color::RED)
+          end
         end.to change { data_store.get_metadata(config) }
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
           .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))
@@ -91,7 +97,9 @@ RSpec.shared_examples "Stoplight::DataStore::Base#transition_to_color" do
 
       it "sets the breached_at and recovery_scheduled_after timestamps" do
         expect do
-          data_store.transition_to_color(config, Stoplight::Color::RED, current_time:)
+          Timecop.freeze(current_time) do
+            data_store.transition_to_color(config, Stoplight::Color::RED)
+          end
         end.to change { data_store.get_metadata(config) }
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
           .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))


### PR DESCRIPTION
Standardize timestamp handling by using the current wall-clock time at the moment of recording, rather than accepting timestamps from callers.

### Before

The code used `failure.time` (when the error occurred) or accepted `request_time` from callers, which could lead to inconsistencies if there's latency between the failure occurrence and recording, and therefore confusion about which timestamp to use.

### After

All events are timestamped with the actual time they were recorded to the data store to ensure windows are calculated based on when the data store saw the event. This:
- Prevents back-dating/future-dating of events -- the events are recorded in order of arrival
- Makes testing cleaner (use Timecop to control time globally)

---

**Context**: This is a prerequisite for implementing more efficient memory data store operations. The current implementation filters all events within a window (_O(n)_), but with guaranteed monotonic insertion, we can maintain running sums that make window queries at _O(log(n))_ time. 