### PR TITLE
Replace array-based metrics with hash-based sliding window for O(1) performance

### DIFF
--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -39,9 +39,9 @@ module Stoplight
       private attr_reader :circuit_breaker
 
       # @param data_store [Stoplight::DataStore::Base]
-      def initialize(data_store)
+      def initialize(data_store, failover_data_store: Default::DATA_STORE)
         @data_store = data_store
-        @failover_data_store = Default::DATA_STORE
+        @failover_data_store = failover_data_store
         @circuit_breaker = Stoplight.system_light("stoplight:data_store:fail_safe:#{data_store.class.name}")
       end
 

--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -11,11 +11,11 @@ module Stoplight
       KEY_SEPARATOR = ":"
 
       def initialize
-        @errors = Hash.new { |h, k| h[k] = [] }
-        @successes = Hash.new { |h, k| h[k] = [] }
+        @errors = Hash.new { |errors, light_name| errors[light_name] = SlidingWindow.new }
+        @successes = Hash.new { |successes, light_name| successes[light_name] = SlidingWindow.new }
 
-        @recovery_probe_errors = Hash.new { |h, k| h[k] = [] }
-        @recovery_probe_successes = Hash.new { |h, k| h[k] = [] }
+        @recovery_probe_errors = Hash.new { |recovery_probe_errors, light_name| recovery_probe_errors[light_name] = SlidingWindow.new }
+        @recovery_probe_successes = Hash.new { |recovery_probe_successes, light_name| recovery_probe_successes[light_name] = SlidingWindow.new }
 
         @metadata = Hash.new { |h, k| h[k] = Metadata.new }
         super # MonitorMixin
@@ -30,50 +30,25 @@ module Stoplight
       # @return [Stoplight::Metadata]
       def get_metadata(config)
         light_name = config.name
-        current_time = self.current_time
-        recovery_window = (current_time - config.cool_off_time)..current_time
 
         synchronize do
+          current_time = self.current_time
+          recovery_window_start = (current_time - config.cool_off_time)
           recovered_at = @metadata[light_name].recovered_at
-          window = if config.window_size
-            window_start = [recovered_at, (current_time - config.window_size)].compact.max
-            (window_start..current_time)
+          window_start = if config.window_size
+            [recovered_at, (current_time - config.window_size)].compact.max
           else
-            (..current_time)
-          end
-
-          errors = @errors[config.name].count do |request_time|
-            window.cover?(request_time)
-          end
-
-          successes = @successes[config.name].count do |request_time|
-            window.cover?(request_time)
-          end
-
-          recovery_probe_errors = @recovery_probe_errors[config.name].count do |request_time|
-            recovery_window.cover?(request_time)
-          end
-          recovery_probe_successes = @recovery_probe_successes[config.name].count do |request_time|
-            recovery_window.cover?(request_time)
+            current_time
           end
 
           @metadata[light_name].with(
             current_time:,
-            errors:,
-            successes:,
-            recovery_probe_errors:,
-            recovery_probe_successes:
+            errors: @errors[config.name].sum_in_window(window_start),
+            successes: @successes[config.name].sum_in_window(window_start),
+            recovery_probe_errors: @recovery_probe_errors[config.name].sum_in_window(recovery_window_start),
+            recovery_probe_successes: @recovery_probe_successes[config.name].sum_in_window(recovery_window_start)
           )
         end
-      end
-
-      # @param metrics [<Time>]
-      # @param window_size [Numeric, nil]
-      # @return [void]
-      def cleanup(metrics, window_size:)
-        min_age = current_time - [window_size&.*(3), METRICS_RETENTION_TIME].compact.min
-
-        metrics.reject! { _1 < min_age }
       end
 
       # @param config [Stoplight::Light::Config]
@@ -84,9 +59,7 @@ module Stoplight
         light_name = config.name
 
         synchronize do
-          @errors[light_name].unshift(current_time) if config.window_size
-
-          cleanup(@errors[light_name], window_size: config.window_size)
+          @errors[light_name].increment if config.window_size
 
           metadata = @metadata[light_name]
           @metadata[light_name] = if metadata.last_error_at.nil? || current_time > metadata.last_error_at
@@ -113,8 +86,7 @@ module Stoplight
         current_time = self.current_time
 
         synchronize do
-          @successes[light_name].unshift(current_time) if config.window_size
-          cleanup(@successes[light_name], window_size: config.window_size)
+          @successes[light_name].increment if config.window_size
 
           metadata = @metadata[light_name]
           @metadata[light_name] = if metadata.last_success_at.nil? || current_time > metadata.last_success_at
@@ -140,8 +112,7 @@ module Stoplight
         current_time = self.current_time
 
         synchronize do
-          @recovery_probe_errors[light_name].unshift(current_time)
-          cleanup(@recovery_probe_errors[light_name], window_size: config.cool_off_time)
+          @recovery_probe_errors[light_name].increment
 
           metadata = @metadata[light_name]
           @metadata[light_name] = if metadata.last_error_at.nil? || current_time > metadata.last_error_at
@@ -168,8 +139,7 @@ module Stoplight
         current_time = self.current_time
 
         synchronize do
-          @recovery_probe_successes[light_name].unshift(current_time)
-          cleanup(@recovery_probe_successes[light_name], window_size: config.cool_off_time)
+          @recovery_probe_successes[light_name].increment
 
           metadata = @metadata[light_name]
           @metadata[light_name] = if metadata.last_success_at.nil? || current_time > metadata.last_success_at

--- a/lib/stoplight/data_store/memory/sliding_window.rb
+++ b/lib/stoplight/data_store/memory/sliding_window.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module DataStore
+    class Memory < Base
+      # Hash-based sliding window for O(1) amortized operations.
+      #
+      # Maintains a running sum and stores per-second counts in a Hash. Ruby's Hash
+      # preserves insertion order (FIFO), allowing efficient removal of expired
+      # buckets from the front via +Hash#shift+, with their counts subtracted from
+      # the running sum.
+      #
+      # Performance: O(1) amortized for both reads and writes
+      # Memory: Bounded to the number of buckets
+      #
+      # @note Not thread-safe; synchronization must be handled externally
+      # @api private
+      class SlidingWindow
+        # @!attribute buckets
+        #   @return [Hash<Integer, Integer>] A hash mapping time buckets to their counts
+        private attr_reader :buckets
+
+        # @!attribute running_sum
+        #   @return [Integer] The running sum of all increments in the current window
+        private attr_accessor :running_sum
+
+        def initialize
+          @buckets = Hash.new { |buckets, bucket| buckets[bucket] = 0 }
+          @running_sum = 0
+        end
+
+        # Increment the count at a given timestamp
+        def increment
+          buckets[current_bucket] += 1
+          self.running_sum += 1
+        end
+
+        # @param window_start [Time]
+        # @return [Integer]
+        def sum_in_window(window_start)
+          slide_window!(window_start)
+          self.running_sum
+        end
+
+        private def slide_window!(window_start)
+          window_start_ts = window_start.to_i
+
+          loop do
+            timestamp, sum = buckets.first
+            if timestamp.nil? || timestamp >= window_start_ts
+              break
+            else
+              self.running_sum -= sum
+              buckets.shift
+            end
+          end
+        end
+
+        private def current_bucket
+          bucket_for_time(current_time)
+        end
+
+        private def bucket_for_time(time)
+          time.to_i
+        end
+
+        private def current_time
+          Time.now
+        end
+
+        def inspect
+          "#<#{self.class.name} #{buckets}>"
+        end
+      end
+    end
+  end
+end

--- a/spec/stoplight/data_store/fail_safe_spec.rb
+++ b/spec/stoplight/data_store/fail_safe_spec.rb
@@ -3,7 +3,8 @@
 require "spec_helper"
 
 RSpec.describe Stoplight::DataStore::FailSafe do
-  let(:fail_safe) { described_class.new(data_store) }
+  let(:fail_safe) { described_class.new(data_store, failover_data_store:) }
+  let(:failover_data_store) { Stoplight::DataStore::Memory.new }
   let(:data_store) { instance_double(Stoplight::DataStore::Base) }
   let(:config) { Stoplight.default_config.with(name:, error_notifier:) }
   let(:error_notifier) { instance_double(Proc) }

--- a/spec/stoplight/data_store/memory/sliding_window_spec.rb
+++ b/spec/stoplight/data_store/memory/sliding_window_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Stoplight::DataStore::Memory::SlidingWindow do
+  let(:counter) { described_class.new }
+
+  around do |example|
+    Timecop.freeze do
+      example.run
+    end
+  end
+
+  describe "#increment" do
+    it "increments the count for the given time" do
+      counter.increment
+      counter.increment
+      counter.increment
+
+      expect(counter.sum_in_window(Time.now - 10)).to eq(3)
+    end
+
+    it "when empty returns zero sum" do
+      expect(counter.sum_in_window(Time.now)).to eq(0)
+      expect(counter.sum_in_window(Time.now - 100)).to eq(0)
+      expect(counter.sum_in_window(Time.now - 10000)).to eq(0)
+    end
+
+    it "increments the count for the different seconds" do
+      Timecop.freeze(Time.now - 2) do
+        counter.increment
+        counter.increment
+      end
+      Timecop.freeze(Time.now - 1) do
+        counter.increment
+        counter.increment
+      end
+      Timecop.freeze(Time.now) do
+        counter.increment
+      end
+
+      expect(counter.sum_in_window(Time.now - 2)).to eq(5)
+      expect(counter.sum_in_window(Time.now - 1)).to eq(3)
+      expect(counter.sum_in_window(Time.now)).to eq(1)
+    end
+
+    it "increments the count for the different sparsely distributed seconds" do
+      Timecop.freeze(Time.now - 20) do
+        counter.increment
+      end
+      Timecop.freeze(Time.now - 10) do
+        counter.increment
+      end
+      Timecop.freeze(Time.now - 5) do
+        counter.increment
+      end
+
+      expect(counter.sum_in_window(Time.now - 60)).to eq(3)
+      expect(counter.sum_in_window(Time.now - 15)).to eq(2)
+      expect(counter.sum_in_window(Time.now - 5)).to eq(1)
+      expect(counter.sum_in_window(Time.now - 2)).to eq(0)
+    end
+  end
+
+  describe "#sum_in_window" do
+    it "returns zero when no increments in the window" do
+      expect(counter.sum_in_window(Time.now)).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Replace array-based time-series storage with hash-based sliding window implementation for O(1) amortized performance in Memory data store.

Performance impact:
- Before: _O(n)_ array traversal on every `get_metadata` call
- After: _O(1)_ amortized hash lookups

Benchmark results (5 minutes run time, over 60s window):
- Before: 312.362 (±71.7%) i/s (3.20 ms/i) with array + count
- After: 94.276k (± 4.0%) i/s (10.61 μs/i) with sliding window

Closes #363 