### PR TITLE
Refactor data stores to handle failure serialization and use float timestamps

### DIFF
--- a/lib/stoplight/domain/data_store.rb
+++ b/lib/stoplight/domain/data_store.rb
@@ -25,9 +25,9 @@ module Stoplight
       # Records a failure for a specific light configuration.
       #
       # @param config [Stoplight::Domain::Config]
-      # @param failure [Failure] The failure to record.
+      # @param exception [Exception]
       # @return [Stoplight::Domain::Metadata] The metadata associated with the light.
-      def record_failure(config, failure)
+      def record_failure(config, exception)
         raise NotImplementedError
       end
 

--- a/lib/stoplight/domain/failure.rb
+++ b/lib/stoplight/domain/failure.rb
@@ -5,9 +5,8 @@ require "time"
 
 module Stoplight
   module Domain
-    class Failure # rubocop:disable Style/Documentation
-      TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%N%:z"
-
+    # @api private
+    class Failure
       # @return [String]
       attr_reader :error_class
       # @return [String]
@@ -21,28 +20,13 @@ module Stoplight
         new(error.class.name, error.message, time)
       end
 
-      # @param json [String]
-      # @return (see #initialize)
-      # @raise [JSON::ParserError]
-      # @raise [ArgumentError]
-      def self.from_json(json)
-        object = JSON.parse(json)
-        error_object = object["error"]
-
-        error_class = error_object["class"]
-        error_message = error_object["message"]
-        time = Time.at(object["time"])
-
-        new(error_class, error_message, time)
-      end
-
       # @param error_class [String]
       # @param error_message [String]
       # @param time [Time]
       def initialize(error_class, error_message, time)
         @error_class = error_class
         @error_message = error_message
-        @time = Time.at(time.to_i) # truncate to seconds
+        @time = time
       end
 
       # @param other [Failure]
@@ -51,22 +35,7 @@ module Stoplight
         other.is_a?(self.class) &&
           error_class == other.error_class &&
           error_message == other.error_message &&
-          time.to_i == other.time.to_i
-      end
-
-      # @param options [Object, nil]
-      # @return [String]
-      def to_json(options = nil)
-        JSON.generate(
-          {
-            error: {
-              class: error_class,
-              message: error_message
-            },
-            time: time.to_i
-          },
-          options
-        )
+          time == other.time
       end
     end
   end

--- a/lib/stoplight/domain/metadata.rb
+++ b/lib/stoplight/domain/metadata.rb
@@ -20,42 +20,6 @@ module Stoplight
       :recovered_at,
       :current_time
     ) do
-      def initialize(
-        current_time: Time.now,
-        successes: 0,
-        errors: 0,
-        recovery_probe_successes: 0,
-        recovery_probe_errors: 0,
-        last_error_at: nil,
-        last_success_at: nil,
-        consecutive_errors: 0,
-        consecutive_successes: 0,
-        last_error: nil,
-        breached_at: nil,
-        locked_state: nil,
-        recovery_started_at: nil,
-        recovery_scheduled_after: nil,
-        recovered_at: nil
-      )
-        super(
-          recovery_probe_successes: recovery_probe_successes.to_i,
-          recovery_probe_errors: recovery_probe_errors.to_i,
-          successes: successes.to_i,
-          errors: errors.to_i,
-          last_error_at: (Time.at(Integer(last_error_at)) if last_error_at),
-          last_success_at: (Time.at(Integer(last_success_at)) if last_success_at),
-          consecutive_errors: consecutive_errors.to_i,
-          consecutive_successes: consecutive_successes.to_i,
-          last_error:,
-          breached_at: (Time.at(Integer(breached_at)) if breached_at),
-          locked_state: locked_state || State::UNLOCKED,
-          recovery_scheduled_after: (Time.at(Integer(recovery_scheduled_after)) if recovery_scheduled_after),
-          recovery_started_at: (Time.at(Integer(recovery_started_at)) if recovery_started_at),
-          recovered_at: (Time.at(Integer(recovered_at)) if recovered_at),
-          current_time:,
-        )
-      end
-
       # YELLOW color could be entered implicitly through a timeout
       # and explicitly through a transition.
       #
@@ -64,16 +28,6 @@ module Stoplight
       # @return [Boolean]
       def recovery_started?
         recovery_started_at && recovery_started_at <= current_time
-      end
-
-      # Creates a new Metadata instance with updated attributes. This method overrides
-      # the default +with+ method provided by +Data.define+ to ensure constructor
-      # logic is applied.
-      #
-      # @param kwargs [Hash{Symbol => Object}]
-      # @return [Metadata]
-      def with(**kwargs)
-        self.class.new(**to_h.merge(current_time: Time.now, **kwargs))
       end
 
       # @return [String] one of +Color::GREEN+, +Color::RED+, or +Color::YELLOW+

--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -33,8 +33,7 @@ module Stoplight
 
         # @param exception [Exception]
         def record_failure(exception)
-          failure = Failure.from_error(exception)
-          metadata = data_store.record_recovery_probe_failure(config, failure)
+          metadata = data_store.record_recovery_probe_failure(config, exception)
 
           recover(metadata)
         end

--- a/lib/stoplight/domain/tracker/request.rb
+++ b/lib/stoplight/domain/tracker/request.rb
@@ -40,8 +40,7 @@ module Stoplight
         # @param exception [Exception]
         # @return [void]
         def record_failure(exception)
-          failure = Failure.from_error(exception)
-          metadata = data_store.record_failure(config, failure)
+          metadata = data_store.record_failure(config, exception)
 
           transition_to_red(exception, metadata:)
         end

--- a/lib/stoplight/infrastructure/data_store/memory.rb
+++ b/lib/stoplight/infrastructure/data_store/memory.rb
@@ -18,7 +18,25 @@ module Stoplight
           @recovery_probe_errors = Hash.new { |recovery_probe_errors, light_name| recovery_probe_errors[light_name] = SlidingWindow.new }
           @recovery_probe_successes = Hash.new { |recovery_probe_successes, light_name| recovery_probe_successes[light_name] = SlidingWindow.new }
 
-          @metadata = Hash.new { |h, k| h[k] = Domain::Metadata.new }
+          @metadata = Hash.new do |metadata, light_name|
+            metadata[light_name] = Domain::Metadata.new(
+              current_time: Time.now,
+              successes: 0,
+              errors: 0,
+              recovery_probe_successes: 0,
+              recovery_probe_errors: 0,
+              last_error: nil,
+              last_error_at: nil,
+              last_success_at: nil,
+              consecutive_errors: 0,
+              consecutive_successes: 0,
+              breached_at: nil,
+              locked_state: Domain::State::UNLOCKED,
+              recovery_scheduled_after: nil,
+              recovery_started_at: nil,
+              recovered_at: nil
+            )
+          end
           super # MonitorMixin
         end
 
@@ -53,11 +71,12 @@ module Stoplight
         end
 
         # @param config [Stoplight::Domain::Config]
-        # @param failure [Stoplight::Failure]
+        # @param exception [Exception]
         # @return [Stoplight::Domain::Metadata]
-        def record_failure(config, failure)
+        def record_failure(config, exception)
           current_time = self.current_time
           light_name = config.name
+          failure = Domain::Failure.from_error(exception, time: current_time)
 
           synchronize do
             @errors[light_name].increment if config.window_size
@@ -106,11 +125,12 @@ module Stoplight
         end
 
         # @param config [Stoplight::Domain::Config]
-        # @param failure [Stoplight::Failure]
+        # @param exception [Exception]
         # @return [Stoplight::Domain::Metadata]
-        def record_recovery_probe_failure(config, failure)
+        def record_recovery_probe_failure(config, exception)
           light_name = config.name
           current_time = self.current_time
+          failure = Domain::Failure.from_error(exception, time: current_time)
 
           synchronize do
             @recovery_probe_errors[light_name].increment

--- a/lib/stoplight/infrastructure/data_store/redis.rb
+++ b/lib/stoplight/infrastructure/data_store/redis.rb
@@ -95,8 +95,8 @@ module Stoplight
         def get_metadata(config)
           detect_clock_skew
 
-          window_end_ts = current_time.to_i
-          window_start_ts = window_end_ts - [config.window_size, METRICS_RETENTION_TIME].compact.min.to_i
+          window_end_ts = current_time.to_f
+          window_start_ts = window_end_ts - [config.window_size, METRICS_RETENTION_TIME].compact.min.to_f
           recovery_window_start_ts = window_end_ts - config.cool_off_time.to_i
 
           if config.window_size
@@ -130,7 +130,7 @@ module Stoplight
           end
           meta_hash = meta.each_slice(2).to_h.transform_keys(&:to_sym)
           last_error_json = meta_hash.delete(:last_error_json)
-          last_error = normalize_failure(last_error_json) if last_error_json
+          last_error = deserialize_failure(last_error_json) if last_error_json
 
           Domain::Metadata.new(
             current_time:,
@@ -139,21 +139,30 @@ module Stoplight
             recovery_probe_successes:,
             recovery_probe_errors:,
             last_error:,
-            **meta_hash
+            last_error_at: (Time.at(meta_hash[:last_error_at].to_f) if meta_hash[:last_error_at]),
+            last_success_at: (Time.at(meta_hash[:last_success_at].to_f) if meta_hash[:last_success_at]),
+            consecutive_errors: meta_hash[:consecutive_errors].to_i,
+            consecutive_successes: meta_hash[:consecutive_successes].to_i,
+            breached_at: (Time.at(meta_hash[:breached_at].to_f) if meta_hash[:breached_at]),
+            locked_state: meta_hash[:locked_state] || Domain::State::UNLOCKED,
+            recovery_scheduled_after: (Time.at(meta_hash[:recovery_scheduled_after].to_f) if meta_hash[:recovery_scheduled_after]),
+            recovery_started_at: (Time.at(meta_hash[:recovery_started_at].to_f) if meta_hash[:recovery_started_at]),
+            recovered_at: (Time.at(meta_hash[:recovered_at].to_f) if meta_hash[:recovered_at])
           )
         end
 
         # @param config [Stoplight::Domain::Config] The light configuration.
-        # @param failure [Stoplight::Failure] The failure to record.
+        # @param exception [Exception]
         # @return [Stoplight::Domain::Metadata] The updated metadata after recording the failure.
-        def record_failure(config, failure)
-          current_ts = current_time.to_i
-          failure_json = failure.to_json
+        def record_failure(config, exception)
+          current_time = self.current_time
+          current_ts = current_time.to_f
+          failure = Domain::Failure.from_error(exception, time: current_time)
 
           @redis.then do |client|
             client.evalsha(
               record_failure_sha,
-              argv: [current_ts, SecureRandom.hex(12), failure_json, metrics_ttl, metadata_ttl],
+              argv: [current_ts, SecureRandom.hex(12), serialize_failure(failure), metrics_ttl, metadata_ttl],
               keys: [
                 metadata_key(config),
                 config.window_size && errors_key(config, time: current_ts)
@@ -164,7 +173,7 @@ module Stoplight
         end
 
         def record_success(config, request_id: SecureRandom.hex(12))
-          current_ts = current_time.to_i
+          current_ts = current_time.to_f
 
           @redis.then do |client|
             client.evalsha(
@@ -181,16 +190,17 @@ module Stoplight
         # Records a failed recovery probe for a specific light configuration.
         #
         # @param config [Stoplight::Domain::Config] The light configuration.
-        # @param failure [Failure] The failure to record.
+        # @param exception [Exception]
         # @return [Stoplight::Domain::Metadata] The updated metadata after recording the failure.
-        def record_recovery_probe_failure(config, failure)
-          current_ts = current_time.to_i
-          failure_json = failure.to_json
+        def record_recovery_probe_failure(config, exception)
+          current_time = self.current_time
+          current_ts = current_time.to_f
+          failure = Domain::Failure.from_error(exception, time: current_time)
 
           @redis.then do |client|
             client.evalsha(
               record_failure_sha,
-              argv: [current_ts, SecureRandom.uuid, failure_json, metrics_ttl, metrics_ttl],
+              argv: [current_ts, SecureRandom.uuid, serialize_failure(failure), metrics_ttl, metrics_ttl],
               keys: [
                 metadata_key(config),
                 recovery_probe_errors_key(config, time: current_ts)
@@ -206,7 +216,7 @@ module Stoplight
         # @param request_id [String] The unique identifier for the request
         # @return [Stoplight::Domain::Metadata] The updated metadata after recording the success.
         def record_recovery_probe_success(config, request_id: SecureRandom.hex(12))
-          current_ts = current_time.to_i
+          current_ts = current_time.to_f
 
           @redis.then do |client|
             client.evalsha(
@@ -255,7 +265,7 @@ module Stoplight
         # @param config [Stoplight::Domain::Config] The light configuration
         # @return [Boolean] true if this is the first instance to detect this transition
         private def transition_to_green(config)
-          current_ts = current_time.to_i
+          current_ts = current_time.to_f
           meta_key = metadata_key(config)
 
           became_green = @redis.then do |client|
@@ -306,8 +316,31 @@ module Stoplight
           became_red == 1
         end
 
-        private def normalize_failure(failure)
-          Domain::Failure.from_json(failure)
+        # @param failure_json [String]
+        # @return [Domain::Failure]
+        private def deserialize_failure(failure_json)
+          object = JSON.parse(failure_json)
+          error_object = object["error"]
+
+          error_class = error_object["class"]
+          error_message = error_object["message"]
+          time = Time.at(object["time"])
+
+          Domain::Failure.new(error_class, error_message, time)
+        end
+
+        # @param failure [Domain::Failure]
+        # @return [String]
+        private def serialize_failure(failure)
+          JSON.generate(
+            {
+              error: {
+                class: failure.error_class,
+                message: failure.error_message
+              },
+              time: failure.time.to_f
+            }
+          )
         end
 
         def_delegator "self.class", :key

--- a/spec/integration/redis_backward_compatibility_spec.rb
+++ b/spec/integration/redis_backward_compatibility_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe "Redis drop-in compatibility", :redis, :freeze do
+  let(:light_name) { SecureRandom.uuid }
+  let(:data_store) { Stoplight::Infrastructure::DataStore::Redis.new(redis) }
+  let(:config) { Stoplight::Domain::Config.empty.with(name: light_name, window_size: 300) }
+
+  def failure_key
+    Stoplight::Infrastructure::DataStore::Redis.bucket_key(light_name, metric: "failure", time: Time.now)
+  end
+
+  def metadata_key
+    Stoplight::Infrastructure::DataStore::Redis.key("metadata", light_name)
+  end
+
+  describe "mixed integer/float timestamp storage" do
+    let(:base_time) { Time.now }
+
+    it "correctly counts errors from old integer timestamps and new float timestamps" do
+      # Simulate OLD version writing integer timestamps
+      Timecop.freeze(base_time - 100) do
+        redis.zadd(failure_key, Time.now.to_i, "old_request_1")
+      end
+
+      Timecop.freeze(base_time - 50) do
+        redis.zadd(failure_key, Time.now.to_i, "old_request_2")
+      end
+
+      # NEW version writes float timestamps
+      Timecop.freeze(base_time) do
+        data_store.record_failure(config, StandardError.new("new error"))
+      end
+
+      # Verify all 3 errors are counted
+      metadata = data_store.get_metadata(config)
+      expect(metadata.errors).to eq(3)
+    end
+
+    it "correctly queries windows with mixed timestamp types" do
+      # Old: integer timestamp outside window
+      Timecop.freeze(base_time - 400) do
+        redis.zadd(failure_key, Time.now.to_i, "old_expired")
+      end
+
+      # Old: integer timestamp inside window
+      Timecop.freeze(base_time - 100) do
+        redis.zadd(failure_key, Time.now.to_i, "old_valid")
+      end
+
+      # New: float timestamp inside window
+      Timecop.freeze(base_time) do
+        data_store.record_failure(config, StandardError.new("new error"))
+      end
+
+      # Should only count the 2 within window (300 seconds)
+      metadata = data_store.get_metadata(config)
+      expect(metadata.errors).to eq(2)
+    end
+
+    it "correctly reads metadata fields with integer timestamps" do
+      # Simulate OLD version writing integer timestamp to metadata hash
+      redis.hset(metadata_key, "last_error_at", Time.now.to_i)
+      redis.hset(metadata_key, "consecutive_errors", "3")
+      redis.hset(metadata_key, "last_error_json", JSON.generate({
+        error: {
+          class: "StandardError",
+          message: "something went wrong"
+        },
+        time: base_time.to_i
+      }))
+
+      # NEW version should read it without issues
+      metadata = data_store.get_metadata(config)
+      expect(metadata.last_error_at).to be_a(Time)
+      expect(metadata.consecutive_errors).to eq(3)
+      expect(metadata.last_error).to have_attributes(
+        error_class: "StandardError",
+        error_message: "something went wrong",
+        time: Time.at(base_time.to_i)
+      )
+    end
+  end
+end

--- a/spec/support/data_store/metrics.rb
+++ b/spec/support/data_store/metrics.rb
@@ -1,667 +1,315 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "data store metrics" do
+  let(:error) { StandardError.new("Test error") }
+  # Redis serialization (Time -> Float -> Redis -> Float -> Time) introduces
+  # sub-microsecond precision loss. This is expected and acceptable.
+  let(:rounding_error) { 0.000001 } # ~1 microsecond tolerance
+
+  def get_metadata
+    data_store.get_metadata(config)
+  end
+
+  def record_failure(error)
+    data_store.record_failure(config, error)
+  end
+
+  def record_success
+    data_store.record_success(config)
+  end
+
+  def record_recovery_probe_failure(error)
+    data_store.record_recovery_probe_failure(config, error)
+  end
+
+  def record_recovery_probe_success
+    data_store.record_recovery_probe_success(config)
+  end
+
   describe "Metadata#last_success_at" do
-    let(:request_time) { Time.at(1746119141) }
+    let(:last_success_time) { Time.now + 30 }
 
-    around do |example|
-      Timecop.freeze(request_time) do
-        example.run
-      end
-    end
+    specify "when success tracked after recovery probe success tracked" do
+      record_recovery_probe_success
 
-    context "when the success is recorded" do
-      it "returns the time of the success" do
-        expect do
-          data_store.record_success(config)
-        end.to change { data_store.get_metadata(config).last_success_at }
-          .from(nil)
-          .to(request_time)
-      end
-    end
-
-    context "when the recovery probe success is recorded" do
-      it "returns the time of the success" do
-        expect do
-          data_store.record_recovery_probe_success(config)
-        end.to change { data_store.get_metadata(config).last_success_at }
-          .from(nil)
-          .to(request_time)
-      end
-    end
-
-    context "when a newer request is recorded after an older one" do
-      before do
-        data_store.record_success(config)
-      end
-
-      it "returns the time of the latest request" do
-        expect do
-          Timecop.freeze(request_time + 20) do
-            data_store.record_success(config)
-          end
-        end.to change { data_store.get_metadata(config).last_success_at }
-          .from(request_time)
-          .to(request_time + 20)
-      end
-    end
-
-    context "when a newer recovery probe success is recorded after a normal request" do
-      let(:recovery_probe_request_time) { request_time + 20 }
-
-      before do
-        data_store.record_success(config)
-      end
-
-      it "returns the time of the latest request" do
-        expect do
-          Timecop.freeze(recovery_probe_request_time) do
-            data_store.record_recovery_probe_success(config)
-          end
-        end.to change { data_store.get_metadata(config).last_success_at }
-          .from(request_time)
-          .to(recovery_probe_request_time)
-      end
-    end
-
-    context "when a success is recorded after a recovery probe success" do
-      let(:recovery_probe_request_time) { request_time - 20 }
-
-      before do
-        Timecop.freeze(recovery_probe_request_time) do
-          data_store.record_recovery_probe_success(config)
+      expect do
+        Timecop.freeze(last_success_time) do
+          record_success
         end
-      end
-
-      it "returns the time of the latest request" do
-        expect do
-          data_store.record_success(config)
-        end.to change { data_store.get_metadata(config).last_success_at }
-          .from(recovery_probe_request_time)
-          .to(request_time)
-      end
+      end.to change { get_metadata.last_success_at }.to(be_within(rounding_error).of(last_success_time))
     end
 
-    context "when a newer recovery probe success is recorded after another recovery probe success" do
-      let(:recovery_probe_request_time) { request_time + 20 }
+    specify "when recovery probe success tracked after success" do
+      record_success
 
-      before do
-        data_store.record_recovery_probe_success(config)
-      end
-
-      it "returns the time of the latest request" do
-        expect do
-          Timecop.freeze(recovery_probe_request_time) do
-            data_store.record_recovery_probe_success(config)
-          end
-        end.to change { data_store.get_metadata(config).last_success_at }
-          .from(request_time)
-          .to(recovery_probe_request_time)
-      end
+      expect do
+        Timecop.freeze(last_success_time) do
+          record_recovery_probe_success
+        end
+      end.to change { get_metadata.last_success_at }.to(be_within(rounding_error).of(last_success_time))
     end
   end
 
   describe "Metadata#last_error_at" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:request_time) { failure.time }
-    let(:error) { StandardError.new("Test error") }
+    let(:last_error_time) { Time.now + 30 }
 
-    around do |example|
-      Timecop.freeze(request_time) do
-        example.run
-      end
-    end
+    specify "when failure tracked after recovery probe failure tracked" do
+      record_recovery_probe_failure(error)
 
-    context "when the failure is recorded" do
-      it "returns the time of the failure" do
-        expect do
-          data_store.record_failure(config, failure)
-        end.to change { data_store.get_metadata(config).last_error_at }
-          .from(nil)
-          .to(request_time)
-      end
-    end
-
-    context "when an older failure is recorded after a newer one" do
-      let(:older_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - 1000) }
-      let(:older_failure_request_time) { request_time + 20 }
-
-      before do
-        data_store.record_failure(config, failure)
-      end
-
-      it "returns the time of the latest recorded failure" do
-        expect do
-          Timecop.freeze(older_failure_request_time) do
-            data_store.record_failure(config, older_failure)
-          end
-        end.to change { data_store.get_metadata(config).last_error_at }
-          .from(request_time)
-          .to(older_failure_request_time)
-      end
-    end
-
-    context "when a newer failure is recorded after an older one" do
-      let(:older_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - 1000) }
-      let(:older_failure_request_time) { request_time - 20 }
-
-      before do
-        Timecop.freeze(older_failure_request_time) do
-          data_store.record_failure(config, older_failure)
+      expect do
+        Timecop.freeze(last_error_time) do
+          record_failure(error)
         end
-      end
-
-      it "returns the time of the latest failure" do
-        expect do
-          data_store.record_failure(config, failure)
-        end.to change { data_store.get_metadata(config).last_error_at }
-          .from(older_failure_request_time)
-          .to(request_time)
-      end
+      end.to change { get_metadata.last_error_at }.to(be_within(rounding_error).of(last_error_time))
     end
 
-    context "when a newer recovery probe failure is recorded after a failure" do
-      let(:recovery_probe_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now + 5000) }
-      let(:recovery_probe_failure_request_time) { request_time + 5000 }
+    specify "when recovery probe failure tracked after failure" do
+      record_failure(error)
 
-      before do
-        data_store.record_failure(config, failure)
-      end
-
-      it "returns the time of the latest failure" do
-        expect do
-          Timecop.freeze(recovery_probe_failure_request_time) do
-            data_store.record_recovery_probe_failure(config, recovery_probe_failure)
-          end
-        end.to change { data_store.get_metadata(config).last_error_at }
-          .from(request_time)
-          .to(recovery_probe_failure_request_time)
-      end
-    end
-
-    context "when a failure is recorded after a recovery probe failure" do
-      let(:recovery_probe_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - 5000) }
-      let(:recovery_probe_failure_request_time) { request_time - 5000 }
-
-      before do
-        Timecop.freeze(recovery_probe_failure_request_time) do
-          data_store.record_recovery_probe_failure(config, recovery_probe_failure)
+      expect do
+        Timecop.freeze(last_error_time) do
+          record_recovery_probe_failure(error)
         end
-      end
-
-      it "returns the time of the latest failure" do
-        expect do
-          data_store.record_failure(config, failure)
-        end.to change { data_store.get_metadata(config).last_error_at }
-          .from(recovery_probe_failure_request_time)
-          .to(request_time)
-      end
+      end.to change { get_metadata.last_error_at }.to(be_within(rounding_error).of(last_error_time))
     end
   end
 
   describe "Metadata#last_error" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
+    let(:another_error) { KeyError.new("key not found: :boom") }
 
-    context "when the failure is recorded" do
-      it "returns last failure" do
-        expect do
-          data_store.record_failure(config, failure)
-        end.to change { data_store.get_metadata(config).last_error }
-          .from(nil)
-          .to(failure)
-      end
+    specify "when failure tracked after recovery probe failure tracked" do
+      expect { record_recovery_probe_failure(error) }.to change { get_metadata.last_error&.error_message }.to eq(error.message)
+      expect { record_failure(another_error) }.to change { get_metadata.last_error.error_message }.to eq(another_error.message)
     end
 
-    context "when an older failure is recorded after a newer one" do
-      let(:older_failure) { Stoplight::Domain::Failure.from_error(older_error, time: Time.now - 5000) }
-      let(:older_error) { StandardError.new("older error") }
-
-      before do
-        data_store.record_failure(config, failure)
-      end
-
-      it "returns the latest recorded failure" do
-        expect(data_store.get_metadata(config).last_error).to eq(failure)
-
-        Timecop.freeze(Time.now + 1) do
-          metadata = data_store.record_failure(config, older_failure)
-
-          expect(metadata.last_error).to eq(older_failure)
-        end
-      end
-    end
-
-    context "when a newer failure is recorded after an older one" do
-      let(:older_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - 1000) }
-      let(:older_failure_request_time) { older_failure.time }
-
-      before do
-        Timecop.freeze(older_failure_request_time) do
-          data_store.record_failure(config, older_failure)
-        end
-      end
-
-      it "returns the time of the latest recorded failure" do
-        expect(data_store.get_metadata(config).last_error).to eq(older_failure)
-
-        data_store.record_failure(config, failure)
-
-        expect(data_store.get_metadata(config).last_error).to eq(failure)
-      end
-    end
-
-    context "when a newer recovery probe failure is recorded after a failure" do
-      let(:recovery_probe_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now + 5000) }
-      let(:recovery_probe_failure_request_time) { recovery_probe_failure.time }
-
-      before do
-        data_store.record_failure(config, failure)
-      end
-
-      it "returns the time of the latest recorded failure" do
-        expect(data_store.get_metadata(config).last_error).to eq(failure)
-
-        Timecop.freeze(recovery_probe_failure_request_time) do
-          data_store.record_recovery_probe_failure(config, recovery_probe_failure)
-        end
-
-        expect(data_store.get_metadata(config).last_error).to eq(recovery_probe_failure)
-      end
-    end
-
-    context "when a failure is recorded after a recovery probe failure" do
-      let(:recovery_probe_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - 5000) }
-      let(:recovery_probe_failure_request_time) { recovery_probe_failure.time }
-
-      before do
-        Timecop.freeze(recovery_probe_failure_request_time) do
-          data_store.record_recovery_probe_failure(config, recovery_probe_failure)
-        end
-      end
-
-      it "returns the time of the latest recorded failure" do
-        expect(data_store.get_metadata(config).last_error).to eq(recovery_probe_failure)
-
-        data_store.record_failure(config, failure)
-
-        expect(data_store.get_metadata(config).last_error).to eq(failure)
-      end
+    specify "when recovery probe failure tracked after failure" do
+      expect { record_failure(error) }.to change { get_metadata.last_error&.error_message }.to eq(error.message)
+      expect { record_recovery_probe_failure(another_error) }.to change { get_metadata.last_error.error_message }.to eq(another_error.message)
     end
   end
 
-  describe "Metadata#success" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
-
+  describe "Metadata#successes" do
     context "without window_size" do
       let(:window_size) { nil }
 
-      it "does not return the the number of successful requests" do
-        expect do
-          data_store.record_success(config)
-        end.not_to change { data_store.get_metadata(config).successes }
+      it "does not increment when a success is recorder" do
+        expect { record_success }.not_to change { get_metadata.successes }
+      end
+
+      it "does not increment when a record_recovery_probe_success is recorder" do
+        expect { record_recovery_probe_success }.not_to change { get_metadata.successes }
       end
     end
 
     context "with window_size" do
       let(:window_size) { 600 }
 
-      context "when the success is recorded" do
-        it "returns the number of successful requests" do
-          expect do
-            data_store.record_success(config)
-          end.to change { data_store.get_metadata(config).successes }.by(1)
+      it "increments when a success is recorder" do
+        expect { record_success }.to change { get_metadata.successes }.by(1)
 
-          expect do
-            data_store.record_success(config)
-          end.to change { data_store.get_metadata(config).successes }.by(1)
-        end
+        expect { record_recovery_probe_failure(error) }.not_to change { get_metadata.successes }.from(1)
+        expect { record_failure(error) }.not_to change { get_metadata.successes }.from(1)
       end
 
-      context "when a failure is recorded after success" do
-        it "returns the the number of successful requests in total" do
-          data_store.record_success(config)
-
-          expect do
-            data_store.record_failure(config, failure)
-            data_store.record_success(config)
-            data_store.record_success(config)
-          end.to change { data_store.get_metadata(config).successes }.from(1).to(3)
-        end
+      it "does not increment when a record_recovery_probe_success is recorder" do
+        expect { record_recovery_probe_success }.not_to change { get_metadata.successes }
       end
 
-      context "when a success is outside of the running window" do
-        let(:window_size) { 5000 }
-
-        it "returns the the number of successful requests within the current window" do
-          Timecop.freeze(Time.now - window_size - 1) do
-            data_store.record_success(config)
-          end
-          data_store.record_success(config)
-          data_store.record_success(config)
-
-          expect(data_store.get_metadata(config).successes).to eq(2)
+      it "does not count a success outside of running window" do
+        Timecop.freeze(Time.now - window_size - 10) do
+          record_success
         end
+
+        expect { record_success }.to change { get_metadata.successes }.from(0).to(1)
       end
     end
   end
 
   describe "Metadata#errors" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
-
     context "without window_size" do
       let(:window_size) { nil }
 
-      it "does not return the number of failed requests" do
-        expect do
-          data_store.record_failure(config, failure)
-        end.not_to change { data_store.get_metadata(config).errors }
+      it "does not increment when a failure is recorder" do
+        expect { record_failure(error) }.not_to change { get_metadata.errors }
+      end
+
+      it "does not increment when a record_recovery_probe_failure is recorder" do
+        expect { record_recovery_probe_failure(error) }.not_to change { get_metadata.errors }
       end
     end
 
     context "with window_size" do
       let(:window_size) { 600 }
 
-      context "when the failure is recorded" do
-        it "returns the the number of failed requests" do
-          expect do
-            data_store.record_failure(config, failure)
-          end.to change { data_store.get_metadata(config).errors }.by(1)
+      it "increments when a failure is recorder" do
+        expect { record_failure(error) }.to change { get_metadata.errors }.by(1)
 
-          expect do
-            data_store.record_failure(config, failure)
-          end.to change { data_store.get_metadata(config).errors }.by(1)
-        end
+        expect { record_recovery_probe_success }.not_to change { get_metadata.errors }.from(1)
+        expect { record_success }.not_to change { get_metadata.errors }.from(1)
       end
 
-      context "when a success is recorded after failure" do
-        it "returns the the number of failed requests in total" do
-          data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-
-          expect do
-            data_store.record_success(config)
-            data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-            data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-          end.to change { data_store.get_metadata(config).errors }.from(1).to(3)
-        end
+      it "does not increment when a record_recovery_probe_failure is recorder" do
+        expect { record_recovery_probe_failure(error) }.not_to change { get_metadata.errors }
       end
 
-      context "when a failure is outside of the running window" do
-        let(:outdated_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - window_size - 1) }
-        let(:window_size) { 5000 }
-
-        it "returns the the number of successful requests within the current window" do
-          Timecop.freeze(outdated_failure.time) do
-            data_store.record_failure(config, outdated_failure)
-          end
-          data_store.record_failure(config, failure)
-          data_store.record_failure(config, failure)
-
-          expect(data_store.get_metadata(config).errors).to eq(2)
+      it "does not count a failure outside of running window" do
+        Timecop.freeze(Time.now - window_size - 10) do
+          record_failure(error)
         end
+
+        expect { record_failure(error) }.to change { get_metadata.errors }.from(0).to(1)
       end
     end
   end
 
   describe "Metadata#recovery_probe_successes" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
+    it "increments when a recovery probe success is recorder" do
+      expect { record_recovery_probe_success }.to change { get_metadata.recovery_probe_successes }.by(1)
 
-    context "when the success is recorded" do
-      it "returns the the number of successful requests" do
-        expect do
-          data_store.record_recovery_probe_success(config)
-        end.to change { data_store.get_metadata(config).recovery_probe_successes }.by(1)
-
-        expect do
-          data_store.record_recovery_probe_success(config)
-        end.to change { data_store.get_metadata(config).recovery_probe_successes }.by(1)
-      end
+      expect { record_recovery_probe_failure(error) }.not_to change { get_metadata.recovery_probe_successes }.from(1)
+      expect { record_failure(error) }.not_to change { get_metadata.recovery_probe_successes }.from(1)
     end
 
-    context "when a failure is recorded after success" do
-      it "returns the the number of successful requests in total" do
-        data_store.record_recovery_probe_success(config)
-
-        expect do
-          data_store.record_recovery_probe_failure(config, failure)
-          data_store.record_success(config) # ignored
-          data_store.record_recovery_probe_success(config)
-          data_store.record_recovery_probe_success(config)
-        end.to change { data_store.get_metadata(config).recovery_probe_successes }.from(1).to(3)
-      end
-    end
-
-    context "when a success is outside of the running window" do
-      let(:window_size) { 5000 }
-
-      it "returns the the number of successful requests within the current window" do
-        Timecop.freeze(Time.now - window_size - 1) do
-          data_store.record_recovery_probe_success(config)
-        end
-        data_store.record_recovery_probe_success(config)
-        data_store.record_recovery_probe_success(config)
-
-        expect(data_store.get_metadata(config).recovery_probe_successes).to eq(2)
-      end
+    it "does not increment when a success is recorder" do
+      expect { record_success }.not_to change { get_metadata.recovery_probe_successes }
     end
   end
 
   describe "Metadata#recovery_probe_errors" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
+    it "increments when a recovery probe failure is recorder" do
+      expect { record_recovery_probe_failure(error) }.to change { get_metadata.recovery_probe_errors }.by(1)
 
-    context "when the failure is recorded" do
-      it "returns the number of failed requests" do
-        expect do
-          data_store.record_recovery_probe_failure(config, failure)
-        end.to change { data_store.get_metadata(config).recovery_probe_errors }.by(1)
-
-        expect do
-          data_store.record_recovery_probe_failure(config, failure)
-        end.to change { data_store.get_metadata(config).recovery_probe_errors }.by(1)
-      end
+      expect { record_recovery_probe_success }.not_to change { get_metadata.recovery_probe_errors }.from(1)
+      expect { record_success }.not_to change { get_metadata.recovery_probe_errors }.from(1)
     end
 
-    context "when a success is recorded after failure" do
-      it "returns the the number of failed requests in total" do
-        data_store.record_recovery_probe_failure(config, Stoplight::Domain::Failure.from_error(error))
-
-        expect do
-          data_store.record_recovery_probe_success(config)
-          data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error)) # ignored
-          data_store.record_recovery_probe_failure(config, Stoplight::Domain::Failure.from_error(error))
-          data_store.record_recovery_probe_failure(config, Stoplight::Domain::Failure.from_error(error))
-        end.to change { data_store.get_metadata(config).recovery_probe_errors }.from(1).to(3)
-      end
-    end
-
-    context "when a failure is outside of the running window" do
-      let(:outdated_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - window_size - 1) }
-      let(:window_size) { 5000 }
-
-      it "returns the the number of successful requests within the current window" do
-        Timecop.freeze(outdated_failure.time) do
-          data_store.record_recovery_probe_failure(config, outdated_failure)
-        end
-        data_store.record_recovery_probe_failure(config, failure)
-        data_store.record_recovery_probe_failure(config, failure)
-
-        expect(data_store.get_metadata(config).recovery_probe_errors).to eq(2)
-      end
+    it "does not increment when a failure is recorder" do
+      expect { record_failure(error) }.not_to change { get_metadata.recovery_probe_errors }
     end
   end
 
   describe "Metadata#consecutive_successes" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
-
-    context "when the success is recorded" do
-      it "returns the the number of successful requests" do
-        expect do
-          data_store.record_success(config)
-        end.to change { data_store.get_metadata(config).consecutive_successes }.by(1)
-
-        expect do
-          data_store.record_success(config)
-        end.to change { data_store.get_metadata(config).consecutive_successes }.by(1)
-      end
+    it "resets when a failure is recorded after success" do
+      expect { record_success }.to change { get_metadata.consecutive_successes }.by(1)
+      expect { record_failure(error) }.to change { get_metadata.consecutive_successes }.to(0)
     end
 
-    context "when a failure is recorded after success" do
-      it "returns the the number of successful requests in total" do
-        data_store.record_success(config)
+    it "increments when the consecutive successes" do
+      expect { record_success }.to change { get_metadata.consecutive_successes }.by(1)
+      expect { record_recovery_probe_success }.to change { get_metadata.consecutive_successes }.by(1)
+    end
 
-        expect do
-          data_store.record_failure(config, failure)
-          data_store.record_success(config)
-          data_store.record_success(config)
-        end.to change { data_store.get_metadata(config).consecutive_successes }.from(1).to(2)
-      end
+    it "resets when a recovery probe failure is recorded after success" do
+      expect { record_success }.to change { get_metadata.consecutive_successes }.by(1)
+      expect { record_recovery_probe_failure(error) }.to change { get_metadata.consecutive_successes }.to(0)
+    end
+
+    it "resets when a failure is recorded after recovery probe success" do
+      expect { record_recovery_probe_success }.to change { get_metadata.consecutive_successes }.by(1)
+      expect { record_failure(error) }.to change { get_metadata.consecutive_successes }.to(0)
+    end
+
+    it "resets when a recovery probe failure is recorded after recovery probe success" do
+      expect { record_recovery_probe_success }.to change { get_metadata.consecutive_successes }.by(1)
+      expect { record_recovery_probe_failure(error) }.to change { get_metadata.consecutive_successes }.to(0)
     end
 
     context "when a success is outside of the running window" do
       let(:window_size) { 5000 }
 
-      it "returns the the number of successful requests within the current window" do
-        Timecop.freeze(Time.now - window_size - 1) do
-          data_store.record_success(config)
+      before do
+        Timecop.freeze(Time.now - window_size - 10) do
+          record_success
         end
-        data_store.record_success(config)
-        data_store.record_success(config)
+      end
 
-        expect(data_store.get_metadata(config).consecutive_successes).to eq(3)
+      # Should we consider this a bug? Shouldn't it count consecutive errors
+      # only withing a window?
+      it "counts consecutive successes outside of the window too" do
+        record_success
+
+        expect(get_metadata.consecutive_successes).to eq(2)
+      end
+    end
+
+    context "when a recovery probe success is outside of the running window" do
+      let(:window_size) { 5000 }
+
+      before do
+        Timecop.freeze(Time.now - window_size - 10) do
+          record_recovery_probe_success
+        end
+      end
+
+      # Should we consider this a bug? Shouldn't it count consecutive errors
+      # only withing a window?
+      it "counts consecutive errors outside of the window too" do
+        record_recovery_probe_success
+
+        expect(get_metadata.consecutive_successes).to eq(2)
       end
     end
   end
 
   describe "Metadata#consecutive_errors" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
-
-    context "when the failure is recorded" do
-      it "returns the the number of failed requests" do
-        expect do
-          data_store.record_failure(config, failure)
-        end.to change { data_store.get_metadata(config).consecutive_errors }.by(1)
-
-        expect do
-          data_store.record_failure(config, failure)
-        end.to change { data_store.get_metadata(config).consecutive_errors }.by(1)
-      end
+    it "resets when a success is recorded after failure" do
+      expect { record_failure(error) }.to change { get_metadata.consecutive_errors }.by(1)
+      expect { record_success }.to change { get_metadata.consecutive_errors }.to(0)
     end
 
-    context "when a success is recorded after failure" do
-      it "returns the the number of failed requests in total" do
-        data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
+    it "increments when the consecutive errors" do
+      expect { record_failure(error) }.to change { get_metadata.consecutive_errors }.by(1)
+      expect { record_recovery_probe_failure(error) }.to change { get_metadata.consecutive_errors }.by(1)
+    end
 
-        expect do
-          data_store.record_success(config)
-          data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-          data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-        end.to change { data_store.get_metadata(config).consecutive_errors }.from(1).to(2)
-      end
+    it "resets when a recovery probe success is recorded after failure" do
+      expect { record_failure(error) }.to change { get_metadata.consecutive_errors }.by(1)
+      expect { record_recovery_probe_success }.to change { get_metadata.consecutive_errors }.to(0)
+    end
+
+    it "resets when a success is recorded after recovery probe failure" do
+      expect { record_recovery_probe_failure(error) }.to change { get_metadata.consecutive_errors }.by(1)
+      expect { record_success }.to change { get_metadata.consecutive_errors }.to(0)
+    end
+
+    it "resets when a recovery probe success is recorded after recovery probe failure" do
+      expect { record_recovery_probe_failure(error) }.to change { get_metadata.consecutive_errors }.by(1)
+      expect { record_recovery_probe_success }.to change { get_metadata.consecutive_errors }.to(0)
     end
 
     context "when a failure is outside of the running window" do
-      let(:outdated_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - window_size - 1) }
       let(:window_size) { 5000 }
 
-      it "returns the the number of successful requests within the current window" do
-        Timecop.freeze(outdated_failure.time) do
-          data_store.record_failure(config, outdated_failure)
+      before do
+        Timecop.freeze(Time.now - window_size - 10) do
+          record_failure(error)
         end
-        data_store.record_failure(config, failure)
-        data_store.record_failure(config, failure)
-
-        expect(data_store.get_metadata(config).consecutive_errors).to eq(3)
       end
-    end
-  end
 
-  describe "#record_failure" do
-    let(:failure) { Stoplight::Domain::Failure.from_error(error) }
-    let(:error) { StandardError.new("Test error") }
-    let(:failure_time) { failure.time }
+      # Should we consider this a bug? Shouldn't it count consecutive errors
+      # only withing a window?
+      it "counts consecutive errors outside of the window too" do
+        record_failure(error)
 
-    context "without window_size" do
-      let(:window_size) { nil }
-
-      it "does not record the number of failed requests" do
-        expect do
-          data_store.record_failure(config, failure)
-        end.to change { data_store.get_metadata(config) }
-          .from(have_attributes(consecutive_errors: 0, last_error_at: nil, last_error: nil))
-          .to(have_attributes(consecutive_errors: 1, last_error_at: failure_time, last_error: failure))
+        expect(get_metadata.consecutive_errors).to eq(2)
       end
     end
 
-    context "with window_size" do
-      let(:window_size) { 600 }
+    context "when a recovery probe failure is outside of the running window" do
+      let(:window_size) { 5000 }
 
-      context "when the failure is recorded" do
-        it "returns the number of failed requests" do
-          expect do
-            data_store.record_failure(config, failure)
-          end.to change { data_store.get_metadata(config) }
-            .from(have_attributes(errors: 0, consecutive_errors: 0, last_error_at: nil, last_error: nil))
-            .to(have_attributes(errors: 1, consecutive_errors: 1, last_error_at: failure_time, last_error: failure))
+      before do
+        Timecop.freeze(Time.now - window_size - 10) do
+          record_recovery_probe_failure(error)
         end
       end
 
-      context "when a success is recorded after failure" do
-        before do
-          data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-        end
+      # Should we consider this a bug? Shouldn't it count consecutive errors
+      # only withing a window?
+      it "counts consecutive errors outside of the window too" do
+        record_failure(error)
 
-        it "returns the the number of failed requests in total" do
-          expect do
-            data_store.record_success(config)
-            data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-            data_store.record_failure(config, Stoplight::Domain::Failure.from_error(error))
-          end.to change { data_store.get_metadata(config) }
-            .from(have_attributes(errors: 1, successes: 0, consecutive_errors: 1))
-            .to(have_attributes(errors: 3, successes: 1, consecutive_errors: 2))
-        end
-      end
-
-      context "when a failure is outside of the running window" do
-        let(:outdated_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - window_size - 1) }
-        let(:window_size) { 300 }
-
-        it "returns the the number of successful errors within the current window" do
-          Timecop.freeze(outdated_failure.time) do
-            data_store.record_failure(config, outdated_failure)
-          end
-          data_store.record_failure(config, failure)
-          data_store.record_failure(config, failure)
-
-          expect(data_store.get_metadata(config)).to have_attributes(
-            errors: 2,
-            consecutive_errors: 3
-          )
-        end
-      end
-
-      context "when a failure after successful recovery" do
-        let(:outdated_failure) { Stoplight::Domain::Failure.from_error(error, time: Time.now - cool_off_time - 1) }
-        let(:cool_off_time) { 60 }
-        let(:window_size) { 300 }
-
-        it "returns the the number of successful errors within the current window after recovery" do
-          Timecop.freeze(outdated_failure.time) do
-            data_store.record_failure(config, outdated_failure)
-          end
-          data_store.transition_to_color(config, Stoplight::Color::RED)
-          data_store.transition_to_color(config, Stoplight::Color::GREEN)
-
-          Timecop.travel(Time.now + 10) do
-            data_store.record_failure(config, failure)
-            expect(data_store.get_metadata(config)).to have_attributes(errors: 1)
-          end
-        end
+        expect(get_metadata.consecutive_errors).to eq(2)
       end
     end
   end

--- a/spec/support/data_store/names.rb
+++ b/spec/support/data_store/names.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "Stoplight::Domain::DataStore#names" do
+  let(:exception) { StandardError.new("Test error") }
+
   it "is initially empty" do
     expect(data_store.names).to eql([])
   end
 
   it "contains the name of a light with a failure" do
-    data_store.record_failure(config, failure)
+    data_store.record_failure(config, exception)
     expect(data_store.names).to eql([config.name])
   end
 
@@ -16,14 +18,14 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#names" do
   end
 
   it "does not duplicate names" do
-    data_store.record_failure(config, failure)
+    data_store.record_failure(config, exception)
     data_store.set_state(config, Stoplight::State::UNLOCKED)
     expect(data_store.names).to eql([config.name])
   end
 
   it "supports names containing colons" do
     Stoplight("http://api.example.com/some/action")
-    data_store.record_failure(config, failure)
+    data_store.record_failure(config, exception)
     expect(data_store.names).to eql([config.name])
   end
 end

--- a/spec/unit/stoplight/domain/failure_spec.rb
+++ b/spec/unit/stoplight/domain/failure_spec.rb
@@ -27,15 +27,6 @@ RSpec.describe Stoplight::Domain::Failure do
     end
   end
 
-  describe ".from_json" do
-    it "parses JSON" do
-      failure = described_class.from_json(json)
-      expect(failure.error_class).to eql(error_class)
-      expect(failure.error_message).to eql(error_message)
-      expect(failure.time).to eql(time)
-    end
-  end
-
   describe "#==" do
     it "is true when they are equal" do
       failure = described_class.new(error_class, error_message, time)
@@ -97,28 +88,6 @@ RSpec.describe Stoplight::Domain::Failure do
       it "returns false" do
         expect(described_class.new(error_class, error_message, time)).not_to eq(other)
       end
-    end
-  end
-
-  describe "#to_json" do
-    it "generates JSON" do
-      expect(described_class.new(error_class, error_message, time).to_json)
-        .to eql(json)
-    end
-
-    it "generates JSON with options" do
-      expect(described_class.new(error_class, error_message, time).to_json({}))
-        .to eql(json)
-    end
-  end
-
-  describe "::TIME_FORMAT" do
-    it "is a string" do
-      expect(described_class::TIME_FORMAT).to be_a(String)
-    end
-
-    it "is frozen" do
-      expect(described_class::TIME_FORMAT).to be_frozen
     end
   end
 end

--- a/spec/unit/stoplight/domain/metadata_spec.rb
+++ b/spec/unit/stoplight/domain/metadata_spec.rb
@@ -1,15 +1,34 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Stoplight::Domain::Metadata do
   let(:current_time) { Time.now }
+
+  def build_metadata(**attributes)
+    Stoplight::Domain::Metadata.new(
+      locked_state: nil,
+      recovery_scheduled_after: nil,
+      recovery_started_at: nil,
+      breached_at: nil,
+      current_time: nil,
+      successes: nil,
+      errors: nil,
+      recovery_probe_successes: nil,
+      recovery_probe_errors: nil,
+      last_error_at: nil,
+      last_success_at: nil,
+      consecutive_errors: nil,
+      consecutive_successes: nil,
+      last_error: nil,
+      recovered_at: nil,
+      **attributes
+    )
+  end
 
   describe "#color" do
     subject(:color) { metadata.color }
 
     let(:metadata) do
-      Stoplight::Domain::Metadata.new(
+      build_metadata(
         locked_state:,
         recovery_scheduled_after:,
         recovery_started_at:,
@@ -56,16 +75,8 @@ RSpec.describe Stoplight::Domain::Metadata do
   end
 
   describe "#error_rate" do
-    context "when there successes or errors are nil" do
-      let(:metadata) { Stoplight::Domain::Metadata.new(successes: nil, errors: nil, current_time:) }
-
-      it "returns 0" do
-        expect(metadata.error_rate).to eq(0)
-      end
-    end
-
     context "when there are no successes or errors" do
-      let(:metadata) { Stoplight::Domain::Metadata.new(successes: 0, errors: 0, current_time:) }
+      let(:metadata) { build_metadata(successes: 0, errors: 0, current_time:) }
 
       it "returns 0" do
         expect(metadata.error_rate).to eq(0)
@@ -73,21 +84,11 @@ RSpec.describe Stoplight::Domain::Metadata do
     end
 
     context "when there are successes and errors" do
-      let(:metadata) { Stoplight::Domain::Metadata.new(successes: 10, errors: 5, current_time:) }
+      let(:metadata) { build_metadata(successes: 10, errors: 5, current_time:) }
 
       it "returns the error rate" do
         expect(metadata.error_rate).to eq(5.fdiv(15))
       end
-    end
-  end
-
-  describe "#with" do
-    subject { metadata.with(successes: "42") }
-
-    let(:metadata) { Stoplight::Domain::Metadata.new(current_time:) }
-
-    it "applies constructor logic" do
-      is_expected.to have_attributes(successes: 42)
     end
   end
 end

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -99,10 +99,9 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     subject(:record_probe) { recorder.record_failure(exception) }
 
     let(:exception) { KeyError.new("bang") }
-    let(:failure_matcher) { have_attributes(error_class: "KeyError", error_message: "bang") }
 
     before do
-      allow(data_store).to receive(:record_recovery_probe_failure).with(config, failure_matcher).and_return(metadata_after_probe)
+      allow(data_store).to receive(:record_recovery_probe_failure).with(config, exception).and_return(metadata_after_probe)
     end
 
     include_examples "recovering after probe"

--- a/spec/unit/stoplight/domain/tracker/request_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/request_spec.rb
@@ -18,10 +18,9 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
   describe "#record_failure" do
     let(:exception) { KeyError.new("something went wrong") }
     let(:metadata) { instance_double(Stoplight::Domain::Metadata) }
-    let(:failure_matcher) { have_attributes(error_class: "KeyError", error_message: "something went wrong") }
 
     before do
-      allow(data_store).to receive(:record_failure).with(config, failure_matcher).and_return(metadata)
+      allow(data_store).to receive(:record_failure).with(config, exception).and_return(metadata)
     end
 
     context "when traffic control decides to stop the traffic" do

--- a/spec/unit/stoplight/domain/traffic_control/consecutive_errors_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/consecutive_errors_spec.rb
@@ -45,7 +45,25 @@ RSpec.describe Stoplight::Domain::TrafficControl::ConsecutiveErrors do
     subject { described_class.new.stop_traffic?(config, metadata) }
 
     let(:config) { Stoplight::Domain::Config.empty.with(threshold:, window_size:) }
-    let(:metadata) { instance_double(Stoplight::Domain::Metadata, consecutive_errors:, errors:) }
+    let(:metadata) do
+      Stoplight::Domain::Metadata.new(
+        errors:,
+        consecutive_errors:,
+        successes: nil,
+        current_time: nil,
+        recovery_probe_successes: nil,
+        recovery_probe_errors: nil,
+        last_error_at: nil,
+        last_success_at: nil,
+        consecutive_successes: nil,
+        last_error: nil,
+        breached_at: nil,
+        locked_state: nil,
+        recovery_scheduled_after: nil,
+        recovery_started_at: nil,
+        recovered_at: nil
+      )
+    end
 
     context "when the window size is not sent" do
       let(:window_size) { nil }

--- a/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
@@ -65,7 +65,25 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
     subject { traffic_control.stop_traffic?(config, metadata) }
 
     let(:config) { Stoplight::Domain::Config.empty.with(window_size: 300, threshold: 0.6) }
-    let(:metadata) { Stoplight::Domain::Metadata.new(successes:, errors:, current_time:) }
+    let(:metadata) do
+      Stoplight::Domain::Metadata.new(
+        successes:,
+        errors:,
+        current_time:,
+        recovery_probe_successes: nil,
+        recovery_probe_errors: nil,
+        last_error_at: nil,
+        last_success_at: nil,
+        consecutive_errors: nil,
+        consecutive_successes: nil,
+        last_error: nil,
+        breached_at: nil,
+        locked_state: nil,
+        recovery_scheduled_after: nil,
+        recovery_started_at: nil,
+        recovered_at: nil
+      )
+    end
 
     context "when there are no requests" do
       let(:successes) { 0 }

--- a/spec/unit/stoplight/domain/traffic_recovery/consecutive_successes_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_recovery/consecutive_successes_spec.rb
@@ -41,7 +41,16 @@ RSpec.describe Stoplight::Domain::TrafficRecovery::ConsecutiveSuccesses do
         last_error_at:,
         recovery_started_at:,
         recovery_scheduled_after:,
-        current_time: Time.now
+        current_time: Time.now,
+        successes: nil,
+        errors: nil,
+        recovery_probe_errors: nil,
+        last_success_at: nil,
+        consecutive_errors: nil,
+        last_error: nil,
+        breached_at: nil,
+        locked_state: nil,
+        recovered_at: nil
       )
     end
     let(:last_error_at) { recovery_started_at - 60 }

--- a/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Memory do
   let(:data_store) { described_class.new }
   let(:config) { Stoplight::Domain::Config.empty.with(name:, window_size:, cool_off_time: 60) }
   let(:name) { ("a".."z").to_a.shuffle.join }
-  let(:failure) { Stoplight::Domain::Failure.new("class", "message", Time.new - 1) }
-  let(:other) { Stoplight::Domain::Failure.new("class", "message 2", Time.new) }
   let(:window_size) { 60 }
 
   it_behaves_like "data store metrics"

--- a/spec/unit/stoplight/wiring/fail_safe_data_store_spec.rb
+++ b/spec/unit/stoplight/wiring/fail_safe_data_store_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Stoplight::Wiring::FailSafeDataStore do
     subject(:get_metadata) { fail_safe.get_metadata(config) }
 
     context "when data_store returns all data" do
-      let(:metadata) { Stoplight::Domain::Metadata.new(errors: 4) }
+      let(:metadata) { instance_double(Stoplight::Domain::Metadata) }
 
       it "returns all data from data_store" do
         expect(error_notifier).not_to receive(:call)
@@ -52,20 +52,20 @@ RSpec.describe Stoplight::Wiring::FailSafeDataStore do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:get_metadata).with(config) { raise error }
 
-        is_expected.to eq(Stoplight::Domain::Metadata.new(current_time: get_metadata.current_time))
+        is_expected.to be_kind_of(Stoplight::Domain::Metadata)
       end
     end
   end
 
   describe "#record_failure" do
-    subject { fail_safe.record_failure(config, failure) }
+    subject { fail_safe.record_failure(config, error) }
 
-    let(:failure) { Stoplight::Domain::Failure.new("class", "message", Time.new) }
+    let(:error) { KeyError.new("unexpected key") }
 
     context "when data_store records failure" do
       it "returns total number of errors from data_store" do
         expect(error_notifier).not_to receive(:call)
-        expect(data_store).to receive(:record_failure).with(config, failure).and_return(4)
+        expect(data_store).to receive(:record_failure).with(config, error).and_return(4)
 
         is_expected.to eq(4)
       end
@@ -74,7 +74,7 @@ RSpec.describe Stoplight::Wiring::FailSafeDataStore do
     context "when data_store fails" do
       it "returns empty list of errors" do
         expect(error_notifier).to receive(:call).with(error)
-        expect(data_store).to receive(:record_failure).with(config, failure) { raise error }
+        expect(data_store).to receive(:record_failure).with(config, error) { raise error }
 
         is_expected.to be_kind_of(Stoplight::Domain::Metadata)
       end
@@ -104,16 +104,16 @@ RSpec.describe Stoplight::Wiring::FailSafeDataStore do
   end
 
   describe "#record_recovery_probe_failure" do
-    subject { fail_safe.record_recovery_probe_failure(config, failure) }
+    subject { fail_safe.record_recovery_probe_failure(config, error) }
 
-    let(:failure) { Stoplight::Domain::Failure.new("class", "message", Time.new) }
+    let(:error) { KeyError.new("unexpected key") }
 
     context "when data_store records recovery probe failure" do
-      let(:metadata) { Stoplight::Domain::Metadata.new(errors: 42, current_time: Time.now) }
+      let(:metadata) { instance_double(Stoplight::Domain::Metadata) }
 
       it "returns metadata from data_store" do
         expect(error_notifier).not_to receive(:call)
-        expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+        expect(data_store).to receive(:record_recovery_probe_failure).with(config, error).and_return(metadata)
 
         is_expected.to eq(metadata)
       end
@@ -122,7 +122,7 @@ RSpec.describe Stoplight::Wiring::FailSafeDataStore do
     context "when data_store fails" do
       it "returns empty metadata" do
         expect(error_notifier).to receive(:call).with(error)
-        expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure) { raise error }
+        expect(data_store).to receive(:record_recovery_probe_failure).with(config, error) { raise error }
 
         is_expected.to be_kind_of(Stoplight::Domain::Metadata)
       end
@@ -133,7 +133,7 @@ RSpec.describe Stoplight::Wiring::FailSafeDataStore do
     subject { fail_safe.record_recovery_probe_success(config) }
 
     context "when data_store records recovery probe success" do
-      let(:metadata) { Stoplight::Domain::Metadata.new(errors: 42, current_time: Time.now) }
+      let(:metadata) { instance_double(Stoplight::Domain::Metadata) }
 
       it "returns metadata from data_store" do
         expect(error_notifier).not_to receive(:call)


### PR DESCRIPTION
This refactoring cleans up how we handle failures and timestamps across data stores, fixing some test flakiness along the way.

### The Problem

We had awkward cases where callers had to construct `Failure` objects before passing them to data stores, even though the `Failure#time` wasn't actually used anywhere in the business logic - it was just test scaffolding. This meant our domain layer knew too much about serialization concerns.

More problematically, we were artificially truncating all timestamps to integer seconds. This was causing intermittent test failures when tests happened to execute right on a second boundary. You'd get different behavior depending on whether `Time.now` was `12:00:00.001` versus `12:00:00.999`

### What Changed

Data stores now accept raw `Exception` objects and handle the conversion to `Failure` internally. This means the Redis store can manage Redis-specific serialization concerns, while the memory store can do its own thing. Each implementation owns its serialization strategy, which is how it should be.

We've also switched to float-based timestamps throughout. This gives us sub-second precision and eliminates those timing-related test failures. When you record a failure at `12:00:00.523456`, that precision is preserved instead of being rounded down 

> ⚠️ Actually, with Redis, there is precision loss because the Redis data store serializes time as floating-point timestamps, leading to rounding errors up to 1 microsecond. This is now handled explicitly in the test suite.

The `Metadata` class got simpler too - it no longer needs that custom constructor that was doing type coercion and conversion. That logic moved into the Redis store where it belongs, since it's really about deserializing Redis strings back into proper Ruby types.

### Why This Matters

Beyond fixing the test flakiness, this sets us up for future work splitting metadata into separate stats and metrics structures. The old test suite relied heavily on `Failure#time` as part of its interface, which would have made that refactoring painful. Now the tests are more natural - they just pass exceptions around like real application code does.

This also allowed us to eliminate many artificial tests. After your refactoring, you literally cannot do this anymore:

```ruby
old_failure = Failure.from_error(error, time: Time.now - 1000)
new_failure = Failure.from_error(error, time: Time.now)
data_store.record_failure(config, old_failure)  # Recording "past" failure
```

Those edge cases like "when an older failure is recorded after a newer one" were testing an API capability that shouldn't exist in production. Real failures always happen "now" - you can't go back in time and insert historical failures.

### Compatibility

This is a drop-in replacement. In Redis old integer timestamps and new float timestamps can coexist peacefully. The compatibility test verifies this works correctly across window queries, metadata reads, and mixed data scenarios.