### PR TITLE
fix: Remove unnecessary require statement

### DIFF
--- a/lib/stoplight/admin.rb
+++ b/lib/stoplight/admin.rb
@@ -2,7 +2,6 @@
 
 begin
   require "sinatra/base"
-  require "sinatra/contrib"
   require "sinatra/json"
 rescue LoadError
   raise <<~WARN


### PR DESCRIPTION
Afaik, the gem only uses "sinatra/json" which is part of "sinatra/contrib" and already required so requiring "sinatra/contrib" here is unnecessary.

I also ran into an issue in my project where this require statement was interfering with the`rake` gem causing some errors so i had to remove this line. See https://stackoverflow.com/questions/20638136/undefined-method-desc-for-sinatraapplicationclass/20642616#20642616 for more details.