### PR TITLE
Move State to Dedicated Storage Classes

### DIFF
--- a/lib/stoplight/infrastructure/storage/fail_safe/state.rb
+++ b/lib/stoplight/infrastructure/storage/fail_safe/state.rb
@@ -26,9 +26,9 @@ module Stoplight
           #   @return [Stoplight::Light] The circuit breaker used to handle store failures.
           private attr_reader :circuit_breaker
 
-          # @param primary_store [Stoplight::Domain::Storage::RecoveryLock]
+          # @param primary_store [Stoplight::Domain::Storage::State]
           # @param error_notifier [Proc]
-          # @param failover_store [Stoplight::Domain::Storage::RecoveryLock]
+          # @param failover_store [Stoplight::Domain::Storage::State]
           # @param circuit_breaker [Stoplight::Domain::Light]
           def initialize(primary_store:, error_notifier:, failover_store:, circuit_breaker:)
             @primary_store = primary_store
@@ -45,6 +45,7 @@ module Stoplight
             end
           end
 
+          # @return [Stoplight::Domain::StateSnapshot]
           def state_snapshot
             circuit_breaker.run(fallback { failover_store.state_snapshot }) do
               primary_store.state_snapshot

--- a/lib/stoplight/infrastructure/storage/fail_safe/state.rb
+++ b/lib/stoplight/infrastructure/storage/fail_safe/state.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Storage
+      module FailSafe
+        # A wrapper around a store that provides fail-safe mechanisms using a
+        # circuit breaker. It ensures that operations on the store can gracefully
+        # handle failures by falling back to default values when necessary.
+        #
+        # @api private
+        class State < Domain::Storage::State
+          # @!attribute primary_store
+          #  @return [Stoplight::Domain::Storage::RecoveryLock] The underlying primary store being used
+          attr_reader :primary_store
+
+          # @!attribute error_notifier
+          #   @return [Proc]
+          attr_reader :error_notifier
+
+          # @!attribute failover_store
+          #   @return [Stoplight::Domain::Storage::RecoveryLock] The fallback store used when the primary fails.
+          attr_reader :failover_store
+
+          # @!attribute circuit_breaker
+          #   @return [Stoplight::Light] The circuit breaker used to handle store failures.
+          private attr_reader :circuit_breaker
+
+          # @param primary_store [Stoplight::Domain::Storage::RecoveryLock]
+          # @param error_notifier [Proc]
+          # @param failover_store [Stoplight::Domain::Storage::RecoveryLock]
+          # @param circuit_breaker [Stoplight::Domain::Light]
+          def initialize(primary_store:, error_notifier:, failover_store:, circuit_breaker:)
+            @primary_store = primary_store
+            @error_notifier = error_notifier
+            @failover_store = failover_store
+            @circuit_breaker = circuit_breaker
+          end
+
+          # @param state [String]
+          # @return [String]
+          def set_state(state)
+            circuit_breaker.run(fallback { failover_store.set_state(state) }) do
+              primary_store.set_state(state)
+            end
+          end
+
+          def state_snapshot
+            circuit_breaker.run(fallback { failover_store.state_snapshot }) do
+              primary_store.state_snapshot
+            end
+          end
+
+          # @param color [String]
+          # @return [Boolean]
+          def transition_to_color(color)
+            circuit_breaker.run(fallback { failover_store.transition_to_color(color) }) do
+              primary_store.transition_to_color(color)
+            end
+          end
+
+          def clear
+            circuit_breaker.run(fallback { failover_store.clear }) do
+              primary_store.clear
+            end
+          end
+
+          private def fallback(&fallback)
+            proc do |error|
+              error_notifier.call(error) if error
+              fallback.call
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/storage/memory/state.rb
+++ b/lib/stoplight/infrastructure/storage/memory/state.rb
@@ -30,13 +30,13 @@ module Stoplight
         # @see Stoplight::Domain::Storage::State for the interface contract
         #
         class State < Domain::Storage::State
-          # @!attribute recovered_at
-          #   @return [Time, nil]
-          private attr_accessor :recovered_at
-
           # @!attribute locked_state
           #   @return [String]
           private attr_accessor :locked_state
+
+          # @!attribute recovered_at
+          #   @return [Time, nil]
+          private attr_accessor :recovered_at
 
           # @!attribute recovery_scheduled_after
           #   @return [Time, nil]
@@ -72,7 +72,7 @@ module Stoplight
           end
 
           # @param state [String]
-          # @return [void]
+          # @return [String]
           def set_state(state)
             mutex.synchronize do
               self.locked_state = state

--- a/lib/stoplight/infrastructure/storage/memory/state.rb
+++ b/lib/stoplight/infrastructure/storage/memory/state.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Memory
+        # Thread-safe in-memory state storage for a single light.
+        #
+        # Manages light state transitions and ensures notification
+        # deduplication through atomic transition detection. Each transition
+        # method returns whether the calling thread was first to trigger that
+        # transition, enabling exactly-once notification semantics.
+        #
+        # @example Basic usage
+        #   state = State.new(clock: SystemClock.new, cool_off_time: 60)
+        #
+        #   # Multiple threads may call this concurrently
+        #   if state.transition_to_color(Domain::Color::RED)
+        #     # Only one thread reaches here - send notification
+        #     notifier.notify(circuit_name, :opened)
+        #   end
+        #
+        # @example Inspecting current state
+        #   snapshot = state.state_snapshot
+        #   snapshot.locked_state        # => "unlocked"
+        #   snapshot.breached_at         # => 2025-01-15 10:30:00 UTC
+        #   snapshot.recovery_scheduled_after  # => 2025-01-15 10:31:00 UTC
+        #
+        # @see Stoplight::Domain::StateSnapshot for the structure of state snapshots
+        # @see Stoplight::Domain::Storage::State for the interface contract
+        #
+        class State < Domain::Storage::State
+          # @!attribute recovered_at
+          #   @return [Time, nil]
+          private attr_accessor :recovered_at
+
+          # @!attribute locked_state
+          #   @return [String]
+          private attr_accessor :locked_state
+
+          # @!attribute recovery_scheduled_after
+          #   @return [Time, nil]
+          private attr_accessor :recovery_scheduled_after
+
+          # @!attribute recovery_started_at
+          #   @return [Time, nil]
+          private attr_accessor :recovery_started_at
+
+          # @!attribute breached_at
+          #   @return [Time, nil]
+          private attr_accessor :breached_at
+
+          # @!attribute mutex
+          #   @return [Thread::Mutex]
+          private attr_reader :mutex
+
+          # @!attribute clock
+          #   @return [Stoplight::Domain::Clock]
+          private attr_reader :clock
+
+          # @!attribute cool_off_time
+          #   @return [Integer]
+          private attr_reader :cool_off_time
+
+          # @param clock [Stoplight::Domain::Clock]
+          # @param cool_off_time [Integer]
+          def initialize(clock:, cool_off_time:)
+            @locked_state = Stoplight::State::UNLOCKED
+            @mutex = Thread::Mutex.new
+            @clock = clock
+            @cool_off_time = cool_off_time
+          end
+
+          # @param state [String]
+          # @return [void]
+          def set_state(state)
+            mutex.synchronize do
+              self.locked_state = state
+            end
+          end
+
+          # @return [Stoplight::Domain::StateSnapshot]
+          def state_snapshot
+            mutex.synchronize do
+              Domain::StateSnapshot.new(
+                time: clock.current_time,
+                locked_state:,
+                recovery_scheduled_after:,
+                recovery_started_at:,
+                breached_at:
+              )
+            end
+          end
+
+          # Combined method that performs the state transition based on color
+          #
+          # @param color [String] The color to transition to ("GREEN", "YELLOW", or "RED")
+          # @return [Boolean] true if this is the first instance to detect this transition
+          def transition_to_color(color)
+            case color
+            when Domain::Color::GREEN
+              transition_to_green
+            when Domain::Color::YELLOW
+              transition_to_yellow
+            when Domain::Color::RED
+              transition_to_red
+            else
+              raise ArgumentError, "Invalid color: #{color}"
+            end
+          end
+
+          # @return [void]
+          def clear
+            mutex.synchronize do
+              self.locked_state = Stoplight::State::UNLOCKED
+              self.recovered_at = nil
+              self.recovery_scheduled_after = nil
+              self.breached_at = nil
+              self.recovery_started_at = nil
+            end
+          end
+
+          # Transitions to GREEN state and ensures only one notification
+          #
+          # @return [Boolean] true if this is the first instance to detect this transition
+          private def transition_to_green
+            mutex.synchronize do
+              if recovered_at
+                false
+              else
+                self.recovered_at = clock.current_time
+                self.recovery_started_at = nil
+                self.breached_at = nil
+                self.recovery_scheduled_after = nil
+                true
+              end
+            end
+          end
+
+          # Transitions to YELLOW (recovery) state and ensures only one notification
+          #
+          # @return [Boolean] true if this is the first instance to detect this transition
+          private def transition_to_yellow
+            mutex.synchronize do
+              if recovery_started_at.nil?
+                self.recovery_started_at = clock.current_time
+                self.recovery_scheduled_after = nil
+                self.recovered_at = nil
+                self.breached_at = nil
+                true
+              else
+                self.recovery_scheduled_after = nil
+                self.recovered_at = nil
+                self.breached_at = nil
+                false
+              end
+            end
+          end
+
+          # Transitions to RED state and ensures only one notification
+          #
+          # @return [Boolean] true if this is the first instance to detect this transition
+          private def transition_to_red
+            mutex.synchronize do
+              current_time = clock.current_time
+
+              self.recovery_scheduled_after = current_time + cool_off_time
+              self.recovery_started_at = nil
+              self.recovered_at = nil
+
+              if breached_at
+                false
+              else
+                self.breached_at = current_time
+                true
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/storage/redis/state.rb
+++ b/lib/stoplight/infrastructure/storage/redis/state.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Redis
+        # Redis-backed state storage for a single circuit breaker.
+        #
+        # Manages circuit breaker state transitions using Redis hashes and Lua scripts
+        # for atomic operations. Ensures notification deduplication across distributed
+        # processes - when multiple processes detect the same circuit condition,
+        # only one will receive +true+ from transition methods.
+        #
+        # All state is stored in a single Redis hash with fields:
+        # - +locked_state+: forced lock (UNLOCKED, LOCKED_GREEN, LOCKED_RED)
+        # - +breached_at+: timestamp (float) when circuit opened
+        # - +recovery_scheduled_after+: timestamp (float) when recovery probe allowed
+        # - +recovery_started_at+: timestamp (float) when recovery probe began
+        #
+        # @example Basic usage
+        #   state = State.new(
+        #     clock: SystemClock.new,
+        #     redis: Redis.new,
+        #     scripting: Scripting.new(redis:),
+        #     key_space: KeySpace.build(light_name: "payments", system_name: "main"),
+        #     cool_off_time: 60
+        #   )
+        #
+        #   # Multiple processes may call this concurrently
+        #   if state.transition_to_color(Domain::Color::RED)
+        #     # Only one process reaches here - send notification
+        #     notifier.notify("payments", :opened)
+        #   end
+        #
+        # @note Thread safety is guaranteed by Redis's single-threaded execution model
+        #   and the use of Lua scripts for atomic multistep operations.
+        #
+        # @see Stoplight::Memory::State for the in-memory equivalent
+        # @see Stoplight::Domain::StateSnapshot for the structure of state snapshots
+        #
+        class State < Domain::Storage::State
+          # @!attribute redis
+          #   @return [::Redis | ConnectionPool<::Redis>]
+          private attr_reader :redis
+
+          # @!attribute scripting
+          #   @return [Stoplight::Infrastructure::DataStore::Redis::Scripting]
+          private attr_reader :scripting
+
+          # @!attribute key_space
+          #   @return [Stoplight::Infrastructure::Storage::Redis::KeySpace]
+          private attr_reader :key_space
+
+          # @!attribute clock
+          #   @return [Stoplight::Domain::Clock]
+          private attr_reader :clock
+
+          # @!attribute cool_off_time
+          #   @return [Integer]
+          private attr_reader :cool_off_time
+
+          # @!attribute state_key
+          #   @return [String]
+          private attr_reader :state_key
+
+          # @param clock [Stoplight::Domain::Clock]
+          # @param redis [::Redis, ConnectionPool<::Redis>]
+          # @param scripting [Stoplight::Infrastructure::DataStore::Redis::Scripting]
+          # @param key_space [Stoplight::Infrastructure::DataStore::Redis::KeySpace]
+          # @param cool_off_time [Integer]
+          def initialize(clock:, redis:, scripting:, key_space:, cool_off_time:)
+            @redis = redis
+            @scripting = scripting
+            @key_space = key_space
+            @clock = clock
+            @cool_off_time = cool_off_time
+
+            @state_key = key_space.key(:state)
+          end
+
+          # @param state [String]
+          # @return [String]
+          def set_state(state)
+            redis.with do |client|
+              client.hset(state_key, "locked_state", state)
+            end
+            state
+          end
+
+          # @return [Stoplight::Domain::StateSnapshot]
+          def state_snapshot
+            breached_at_raw, locked_state, recovery_scheduled_after_raw, recovery_started_at_raw = redis.with do |client|
+              client.hmget(state_key, :breached_at, :locked_state, :recovery_scheduled_after, :recovery_started_at)
+            end
+
+            Domain::StateSnapshot.new(
+              breached_at: breached_at_raw && clock.at(breached_at_raw.to_f),
+              locked_state: locked_state || Domain::State::UNLOCKED,
+              recovery_scheduled_after: recovery_scheduled_after_raw && clock.at(recovery_scheduled_after_raw.to_f),
+              recovery_started_at: recovery_started_at_raw && clock.at(recovery_started_at_raw.to_f),
+              time: clock.current_time
+            )
+          end
+
+          # @return [void]
+          def clear
+            redis.with do |client|
+              client.del(state_key)
+            end
+          end
+
+          def transition_to_color(color)
+            case color
+            when Domain::Color::GREEN
+              transition_to_green
+            when Domain::Color::YELLOW
+              transition_to_yellow
+            when Domain::Color::RED
+              transition_to_red
+            else
+              raise ArgumentError, "Invalid color: #{color}"
+            end
+          end
+
+          # Transitions to GREEN state and ensures only one notification
+          #
+          # @return [Boolean] true if this is the first instance to detect this transition
+          private def transition_to_green
+            became_green = scripting.call(
+              :transition_to_green,
+              args: [clock.current_time.to_f],
+              keys: [state_key]
+            )
+            became_green == 1
+          end
+
+          # Transitions to YELLOW (recovery) state and ensures only one notification
+          #
+          # @return [Boolean] true if this is the first instance to detect this transition
+          private def transition_to_yellow
+            became_yellow = scripting.call(
+              :transition_to_yellow,
+              args: [clock.current_time.to_f],
+              keys: [state_key]
+            )
+            became_yellow == 1
+          end
+
+          # Transitions to RED state and ensures only one notification
+          #
+          # @return [Boolean] true if this is the first instance to detect this transition
+          private def transition_to_red
+            current_ts = clock.current_time.to_f
+            recovery_scheduled_after_ts = current_ts + cool_off_time
+
+            became_red = scripting.call(
+              :transition_to_red,
+              args: [current_ts, recovery_scheduled_after_ts],
+              keys: [state_key]
+            )
+
+            became_red == 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/system/light_builder.rb
+++ b/lib/stoplight/wiring/system/light_builder.rb
@@ -12,10 +12,32 @@ module Stoplight
           super(settings)
         end
 
-        def key_space = Infrastructure::Storage::Redis::KeySpace.build(
+        def key_space = @key_space ||= Infrastructure::Storage::Redis::KeySpace.build(
           system_name: system.name,
           light_name: config.name
         )
+
+        def cool_off_time = config.cool_off_time
+
+        private def state_store
+          @state_store ||= case data_store_config
+          in Stoplight::DataStore::Memory
+            Infrastructure::Storage::Memory::State.new(clock:, cool_off_time:)
+          in Stoplight::DataStore::Redis
+            Infrastructure::Storage::FailSafe::State.new(
+              primary_store: Infrastructure::Storage::Redis::State.new(
+                redis: data_store_config.redis,
+                scripting:,
+                key_space:,
+                cool_off_time:,
+                clock:
+              ),
+              error_notifier:,
+              failover_store: Infrastructure::Storage::Memory::State.new(clock:, cool_off_time:),
+              circuit_breaker: failover_system.light("redis")
+            )
+          end
+        end
 
         private def redis = data_store_config
         private def storage_scripting = Infrastructure::Storage::Redis::Scripting.new(redis:)

--- a/spec/support/data_store/set_state.rb
+++ b/spec/support/data_store/set_state.rb
@@ -12,4 +12,12 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#set_state" do
 
     expect(state_snapshot.locked_state).to eql(state)
   end
+
+  context "when cleared" do
+    it "looses persisted state" do
+      set_state(state)
+      clear
+      expect(state_snapshot.locked_state).to eql(Stoplight::State::UNLOCKED)
+    end
+  end
 end

--- a/spec/support/data_store/set_state.rb
+++ b/spec/support/data_store/set_state.rb
@@ -10,6 +10,6 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#set_state" do
   it "persists the state" do
     set_state(state)
 
-    expect(get_state_snapshot.locked_state).to eql(state)
+    expect(state_snapshot.locked_state).to eql(state)
   end
 end

--- a/spec/support/data_store/set_state.rb
+++ b/spec/support/data_store/set_state.rb
@@ -4,12 +4,12 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#set_state" do
   let(:state) { "state" }
 
   it "returns the state" do
-    expect(data_store.set_state(config, state)).to eql(state)
+    expect(set_state(state)).to eql(state)
   end
 
   it "persists the state" do
-    data_store.set_state(config, state)
+    set_state(state)
 
-    expect(data_store.get_state_snapshot(config).locked_state).to eql(state)
+    expect(get_state_snapshot.locked_state).to eql(state)
   end
 end

--- a/spec/support/data_store/transition_to_color.rb
+++ b/spec/support/data_store/transition_to_color.rb
@@ -3,6 +3,26 @@
 RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
   let(:current_time) { Time.at(Time.now.to_i) }
 
+  shared_examples "thread safe" do |color|
+    let(:thread_count) { 50 }
+    let(:barrier) { Concurrent::CyclicBarrier.new(thread_count) }
+    let(:transition_results) { Concurrent::Array.new }
+
+    it "returns true exactly once across concurrent calls" do
+      threads = thread_count.times.map do
+        Thread.new do
+          barrier.wait  # All threads release simultaneously
+          transition_results << transition_to_color(color)
+        end
+      end
+
+      threads.each(&:join)
+
+      expect(transition_results.count(true)).to eq(1)
+      expect(transition_results.count(false)).to eq(thread_count - 1)
+    end
+  end
+
   context "when transitioning to GREEN" do
     context "when the color is already GREEN" do
       before do
@@ -30,6 +50,8 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           recovery_scheduled_after: nil
         )
       end
+
+      it_behaves_like "thread safe", Stoplight::Color::GREEN
     end
   end
 
@@ -68,6 +90,8 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           expect(state_snapshot).to have_attributes(recovery_started_at: nil)
         end
       end
+
+      it_behaves_like "thread safe", Stoplight::Color::YELLOW
     end
   end
 
@@ -94,7 +118,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           end
         end.to change { state_snapshot }
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
-          .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))
+          .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + cool_off_time))
       end
 
       context "when cleared" do
@@ -106,6 +130,8 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           expect(state_snapshot).to have_attributes(breached_at: nil, recovery_scheduled_after: nil)
         end
       end
+
+      it_behaves_like "thread safe", Stoplight::Color::RED
     end
 
     context "when the color is GREEN" do
@@ -122,7 +148,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           end
         end.to change { state_snapshot }
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
-          .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))
+          .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + cool_off_time))
       end
 
       context "when cleared" do
@@ -134,6 +160,8 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           expect(state_snapshot).to have_attributes(breached_at: nil, recovery_scheduled_after: nil)
         end
       end
+
+      it_behaves_like "thread safe", Stoplight::Color::RED
     end
 
     context "when transitioning to an invalid color" do

--- a/spec/support/data_store/transition_to_color.rb
+++ b/spec/support/data_store/transition_to_color.rb
@@ -58,6 +58,16 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           .from(have_attributes(recovery_started_at: nil))
           .to(have_attributes(recovery_started_at: current_time))
       end
+
+      context "when cleared" do
+        it "looses persisted state" do
+          Timecop.freeze(current_time) do
+            transition_to_color(Stoplight::Color::YELLOW)
+          end
+          clear
+          expect(state_snapshot).to have_attributes(recovery_started_at: nil)
+        end
+      end
     end
   end
 
@@ -86,6 +96,16 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
           .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))
       end
+
+      context "when cleared" do
+        it "looses persisted state" do
+          Timecop.freeze(current_time) do
+            transition_to_color(Stoplight::Color::YELLOW)
+          end
+          clear
+          expect(state_snapshot).to have_attributes(breached_at: nil, recovery_scheduled_after: nil)
+        end
+      end
     end
 
     context "when the color is GREEN" do
@@ -103,6 +123,16 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
         end.to change { state_snapshot }
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
           .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))
+      end
+
+      context "when cleared" do
+        it "looses persisted state" do
+          Timecop.freeze(current_time) do
+            transition_to_color(Stoplight::Color::YELLOW)
+          end
+          clear
+          expect(state_snapshot).to have_attributes(breached_at: nil, recovery_scheduled_after: nil)
+        end
       end
     end
 

--- a/spec/support/data_store/transition_to_color.rb
+++ b/spec/support/data_store/transition_to_color.rb
@@ -6,25 +6,25 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
   context "when transitioning to GREEN" do
     context "when the color is already GREEN" do
       before do
-        data_store.transition_to_color(config, Stoplight::Color::GREEN)
+        transition_to_color(Stoplight::Color::GREEN)
       end
 
-      it { expect(data_store.transition_to_color(config, Stoplight::Color::GREEN)).to be(false) }
+      it { expect(transition_to_color(Stoplight::Color::GREEN)).to be(false) }
     end
 
     context "when the color is YELLOW" do
       before do
-        data_store.transition_to_color(config, Stoplight::Color::YELLOW)
+        transition_to_color(Stoplight::Color::YELLOW)
       end
 
-      it { expect(data_store.transition_to_color(config, Stoplight::Color::GREEN)).to be(true) }
+      it { expect(transition_to_color(Stoplight::Color::GREEN)).to be(true) }
 
       it "resets timestamps" do
         Timecop.freeze(current_time) do
-          data_store.transition_to_color(config, Stoplight::Color::GREEN)
+          transition_to_color(Stoplight::Color::GREEN)
         end
 
-        expect(data_store.get_state_snapshot(config)).to have_attributes(
+        expect(state_snapshot).to have_attributes(
           recovery_started_at: nil,
           breached_at: nil,
           recovery_scheduled_after: nil
@@ -36,25 +36,25 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
   context "when transitioning to YELLOW" do
     context "when the color is already YELLOW" do
       before do
-        data_store.transition_to_color(config, Stoplight::Color::YELLOW)
+        transition_to_color(Stoplight::Color::YELLOW)
       end
 
-      it { expect(data_store.transition_to_color(config, Stoplight::Color::YELLOW)).to be(false) }
+      it { expect(transition_to_color(Stoplight::Color::YELLOW)).to be(false) }
     end
 
     context "when the color is RED" do
       before do
-        data_store.transition_to_color(config, Stoplight::Color::RED)
+        transition_to_color(Stoplight::Color::RED)
       end
 
-      it { expect(data_store.transition_to_color(config, Stoplight::Color::YELLOW)).to be(true) }
+      it { expect(transition_to_color(Stoplight::Color::YELLOW)).to be(true) }
 
       it "sets the recovery_started_at timestamp" do
         expect do
           Timecop.freeze(current_time) do
-            data_store.transition_to_color(config, Stoplight::Color::YELLOW)
+            transition_to_color(Stoplight::Color::YELLOW)
           end
-        end.to change { data_store.get_state_snapshot(config) }
+        end.to change { state_snapshot }
           .from(have_attributes(recovery_started_at: nil))
           .to(have_attributes(recovery_started_at: current_time))
       end
@@ -64,25 +64,25 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
   context "when transitioning to RED" do
     context "when the color is already RED" do
       before do
-        data_store.transition_to_color(config, Stoplight::Color::RED)
+        transition_to_color(Stoplight::Color::RED)
       end
 
-      it { expect(data_store.transition_to_color(config, Stoplight::Color::RED)).to be(false) }
+      it { expect(transition_to_color(Stoplight::Color::RED)).to be(false) }
     end
 
     context "when the color is YELLOW" do
       before do
-        data_store.transition_to_color(config, Stoplight::Color::YELLOW)
+        transition_to_color(Stoplight::Color::YELLOW)
       end
 
-      it { expect(data_store.transition_to_color(config, Stoplight::Color::RED)).to be(true) }
+      it { expect(transition_to_color(Stoplight::Color::RED)).to be(true) }
 
       it "sets the breached_at and recovery_scheduled_after timestamps" do
         expect do
           Timecop.freeze(current_time) do
-            data_store.transition_to_color(config, Stoplight::Color::RED)
+            transition_to_color(Stoplight::Color::RED)
           end
-        end.to change { data_store.get_state_snapshot(config) }
+        end.to change { state_snapshot }
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
           .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))
       end
@@ -90,17 +90,17 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
 
     context "when the color is GREEN" do
       before do
-        data_store.transition_to_color(config, Stoplight::Color::GREEN)
+        transition_to_color(Stoplight::Color::GREEN)
       end
 
-      it { expect(data_store.transition_to_color(config, Stoplight::Color::RED)).to be(true) }
+      it { expect(transition_to_color(Stoplight::Color::RED)).to be(true) }
 
       it "sets the breached_at and recovery_scheduled_after timestamps" do
         expect do
           Timecop.freeze(current_time) do
-            data_store.transition_to_color(config, Stoplight::Color::RED)
+            transition_to_color(Stoplight::Color::RED)
           end
-        end.to change { data_store.get_state_snapshot(config) }
+        end.to change { state_snapshot }
           .from(have_attributes(breached_at: nil, recovery_scheduled_after: nil))
           .to(have_attributes(breached_at: current_time, recovery_scheduled_after: current_time + config.cool_off_time))
       end
@@ -109,7 +109,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
     context "when transitioning to an invalid color" do
       it "raises an ArgumentError" do
         expect {
-          data_store.transition_to_color(config, "INVALID_COLOR")
+          transition_to_color("INVALID_COLOR")
         }.to raise_error(ArgumentError, "Invalid color: INVALID_COLOR")
       end
     end

--- a/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Memory do
   it_behaves_like "Stoplight::Domain::DataStore#set_state" do
     def set_state(state) = data_store.set_state(config, state)
     def state_snapshot = data_store.get_state_snapshot(config)
+    def clear = data_store.delete_light(config)
   end
   it_behaves_like "Stoplight::Domain::DataStore#transition_to_color" do
     def transition_to_color(color) = data_store.transition_to_color(config, color)
     def state_snapshot = data_store.get_state_snapshot(config)
+    def clear = data_store.delete_light(config)
   end
 
   describe "#acquire_recovery_lock" do

--- a/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
@@ -19,9 +19,12 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Memory do
   it_behaves_like "Stoplight::Domain::DataStore#names"
   it_behaves_like "Stoplight::Domain::DataStore#set_state" do
     def set_state(state) = data_store.set_state(config, state)
-    def get_state_snapshot = data_store.get_state_snapshot(config)
+    def state_snapshot = data_store.get_state_snapshot(config)
   end
-  it_behaves_like "Stoplight::Domain::DataStore#transition_to_color"
+  it_behaves_like "Stoplight::Domain::DataStore#transition_to_color" do
+    def transition_to_color(color) = data_store.transition_to_color(config, color)
+    def state_snapshot = data_store.get_state_snapshot(config)
+  end
 
   describe "#acquire_recovery_lock" do
     let(:recovery_lock) { instance_double(described_class::RecoveryLockToken) }

--- a/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Memory do
   it_behaves_like "Stoplight::Domain::DataStore#get_metrics"
   it_behaves_like "Stoplight::Domain::DataStore#get_recovery_metrics"
   it_behaves_like "Stoplight::Domain::DataStore#names"
-  it_behaves_like "Stoplight::Domain::DataStore#set_state"
+  it_behaves_like "Stoplight::Domain::DataStore#set_state" do
+    def set_state(state) = data_store.set_state(config, state)
+    def get_state_snapshot = data_store.get_state_snapshot(config)
+  end
   it_behaves_like "Stoplight::Domain::DataStore#transition_to_color"
 
   describe "#acquire_recovery_lock" do

--- a/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
@@ -181,7 +181,10 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Redis, :redis do
     it_behaves_like "Stoplight::Domain::DataStore#get_metrics"
     it_behaves_like "Stoplight::Domain::DataStore#get_recovery_metrics"
     it_behaves_like "Stoplight::Domain::DataStore#names"
-    it_behaves_like "Stoplight::Domain::DataStore#set_state"
+    it_behaves_like "Stoplight::Domain::DataStore#set_state" do
+      def set_state(state) = data_store.set_state(config, state)
+      def get_state_snapshot = data_store.get_state_snapshot(config)
+    end
     it_behaves_like "Stoplight::Domain::DataStore#transition_to_color"
   end
 

--- a/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
@@ -183,9 +183,12 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Redis, :redis do
     it_behaves_like "Stoplight::Domain::DataStore#names"
     it_behaves_like "Stoplight::Domain::DataStore#set_state" do
       def set_state(state) = data_store.set_state(config, state)
-      def get_state_snapshot = data_store.get_state_snapshot(config)
+      def state_snapshot = data_store.get_state_snapshot(config)
     end
-    it_behaves_like "Stoplight::Domain::DataStore#transition_to_color"
+    it_behaves_like "Stoplight::Domain::DataStore#transition_to_color" do
+      def transition_to_color(color) = data_store.transition_to_color(config, color)
+      def state_snapshot = data_store.get_state_snapshot(config)
+    end
   end
 
   it_behaves_like Stoplight::Infrastructure::DataStore::Redis do

--- a/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
@@ -184,10 +184,12 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Redis, :redis do
     it_behaves_like "Stoplight::Domain::DataStore#set_state" do
       def set_state(state) = data_store.set_state(config, state)
       def state_snapshot = data_store.get_state_snapshot(config)
+      def clear = data_store.delete_light(config)
     end
     it_behaves_like "Stoplight::Domain::DataStore#transition_to_color" do
       def transition_to_color(color) = data_store.transition_to_color(config, color)
       def state_snapshot = data_store.get_state_snapshot(config)
+      def clear = data_store.delete_light(config)
     end
   end
 

--- a/spec/unit/stoplight/infrastructure/storage/fail_safe/state_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/fail_safe/state_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::Storage::FailSafe::State do
+  let(:fail_safe) do
+    described_class.new(
+      primary_store:, error_notifier:, failover_store:,
+      circuit_breaker: test_circuit_breaker_class.new
+    )
+  end
+  let(:failover_store) { instance_double(Stoplight::Domain::Storage::State) }
+  let(:primary_store) { instance_double(Stoplight::Domain::Storage::State) }
+  let(:error_notifier) { instance_double(Proc) }
+
+  let(:test_circuit_breaker_class) do
+    Class.new(Stoplight::Domain::Light) do
+      def initialize
+      end
+
+      def run(fallback)
+        yield
+      rescue => exception
+        fallback.call(exception)
+      end
+    end
+  end
+
+  describe "#set_state" do
+    subject { fail_safe.set_state(state) }
+
+    context "when primary store does not fail" do
+      let(:state) { instance_double(String) }
+
+      it "returns state from primary store" do
+        expect(primary_store).to receive(:set_state).with(state).and_return(state)
+
+        is_expected.to eq(state)
+      end
+    end
+
+    context "when primary store fails" do
+      let(:error) { StandardError.new("Test error") }
+      let(:state) { instance_double(String) }
+
+      it "sets state on failover state" do
+        expect(error_notifier).to receive(:call).with(error)
+        expect(primary_store).to receive(:set_state).with(state) { raise error }
+        expect(failover_store).to receive(:set_state).with(state).and_return(state)
+
+        is_expected.to eq(state)
+      end
+    end
+  end
+
+  describe "#state_snapshot" do
+    subject { fail_safe.state_snapshot }
+
+    context "when primary store does not fail" do
+      let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot) }
+
+      it "returns state snapshot from primary store" do
+        expect(primary_store).to receive(:state_snapshot).and_return(state_snapshot)
+
+        is_expected.to eq(state_snapshot)
+      end
+    end
+
+    context "when store fails" do
+      let(:error) { StandardError.new("Test error") }
+      let(:failover_state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot) }
+
+      it "sets state on failover state" do
+        expect(error_notifier).to receive(:call).with(error)
+        expect(primary_store).to receive(:state_snapshot) { raise error }
+        expect(failover_store).to receive(:state_snapshot).and_return(failover_state_snapshot)
+
+        is_expected.to eq(failover_state_snapshot)
+      end
+    end
+  end
+
+  describe "#transition_to_color" do
+    subject { fail_safe.transition_to_color(color) }
+
+    let(:color) { Stoplight::Color::GREEN }
+    let(:transition_result) { rand }
+
+    context "when primary store does not fail" do
+      it "returns the transition result" do
+        expect(primary_store).to receive(:transition_to_color).with(color).and_return(transition_result)
+
+        is_expected.to eq(transition_result)
+      end
+    end
+
+    context "when primary store fails" do
+      let(:error) { StandardError.new("Test error") }
+
+      it "returns result from failover" do
+        expect(error_notifier).to receive(:call).with(error)
+        expect(primary_store).to receive(:transition_to_color).with(color).and_raise(error)
+        expect(failover_store).to receive(:transition_to_color).with(color).and_return(transition_result)
+
+        is_expected.to eq(transition_result)
+      end
+    end
+  end
+
+  describe "#clear" do
+    subject(:clear) { fail_safe.clear }
+
+    context "when primary store does not fail" do
+      it "clears state in the primary store" do
+        expect(primary_store).to receive(:clear)
+
+        clear
+      end
+    end
+
+    context "when primary store fails" do
+      let(:error) { StandardError.new("Test error") }
+
+      it "sets state on failover state" do
+        expect(error_notifier).to receive(:call).with(error)
+        expect(primary_store).to receive(:clear) { raise error }
+        expect(failover_store).to receive(:clear)
+
+        clear
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/infrastructure/storage/memory/state_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/memory/state_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::Storage::Memory::State do
+  subject(:storage) { described_class.new(clock:, cool_off_time:) }
+
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
+  let(:cool_off_time) { 60 }
+
+  def state_snapshot = storage.state_snapshot
+  def clear = storage.clear
+
+  it_behaves_like "Stoplight::Domain::DataStore#set_state" do
+    def set_state(state) = storage.set_state(state)
+  end
+
+  it_behaves_like "Stoplight::Domain::DataStore#transition_to_color" do
+    def transition_to_color(color) = storage.transition_to_color(color)
+  end
+end

--- a/spec/unit/stoplight/infrastructure/storage/redis/state_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/redis/state_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::Storage::Redis::State, :redis do
+  shared_examples Stoplight::Infrastructure::Storage::Redis::State do
+    subject(:storage) { described_class.new(clock:, redis: connection, scripting:, key_space:, cool_off_time:) }
+
+    let(:scripting) { Stoplight::Infrastructure::DataStore::Redis::Scripting.new(redis:) }
+    let(:key_space) { Stoplight::Infrastructure::Storage::Redis::KeySpace.build(light_name:, system_name:) }
+    let(:clock) { Stoplight::Infrastructure::SystemClock.new }
+
+    let(:light_name) { SecureRandom.uuid }
+    let(:system_name) { SecureRandom.uuid }
+    let(:cool_off_time) { 60 }
+
+    def state_snapshot = storage.state_snapshot
+    def clear = storage.clear
+
+    it_behaves_like "Stoplight::Domain::DataStore#set_state" do
+      def set_state(state) = storage.set_state(state)
+    end
+
+    it_behaves_like "Stoplight::Domain::DataStore#transition_to_color" do
+      def transition_to_color(color) = storage.transition_to_color(color)
+    end
+  end
+
+  it_behaves_like Stoplight::Infrastructure::Storage::Redis::State do
+    let(:connection) { redis }
+  end
+
+  it_behaves_like Stoplight::Infrastructure::Storage::Redis::State do
+    let(:connection) { ConnectionPool.new(size: 1, timeout: 5, &redis_client_factory) }
+  end
+end


### PR DESCRIPTION
Continues storage abstraction separation by extracting state management from DataStore into dedicated per-circuit storage instances.

Previously, we introduced the `Domain::Storage::State` interface. This PR implements the actual storage classes following the same pattern as recovery locks.

**Before:** DataStore handled state for ALL circuits:

```ruby
data_store.set_state(config, state)
snapshot = data_store.get_state_snapshot(config)
first_to_transition = data_store.transition_to_color(config, Color::RED)
```

**After:** each circuit has its own state storage instance:

```ruby
state_store = Memory::State.new(clock:, cool_off_time:)  # Per circuit
state_store.set_state(state)  # No config needed - knows its circuit
snapshot = state_store.state_snapshot
first_to_transition = state_store.transition_to_color(Color::RED)
```

Also introduces `Domain::Clock` interface with `Infrastructure::SystemClock` implementation, making time dependencies explicit and testable.

The Redis implementation is composed with `FailSafe::State` decorator for automatic memory failover, wired in `LightBuilder`.