### PR TITLE
Extract unbounded metrics into per-light storage

### DIFF
--- a/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
@@ -13,7 +13,12 @@ module Stoplight
           #   @return [Mutex]
           private attr_reader :mutex
 
-          def initialize
+          # @!attribute clock
+          #   @return [Stoplight::Domain::Clock]
+          private attr_reader :clock
+
+          def initialize(clock:)
+            @clock = clock
             @mutex = Mutex.new
             @metrics = DataStore::Memory::Metrics.new
           end
@@ -38,7 +43,7 @@ module Stoplight
           #
           # @return [void]
           def record_success
-            current_time = self.current_time
+            current_time = clock.current_time
 
             mutex.synchronize do
               if metrics.last_success_at.nil? || current_time > metrics.last_success_at
@@ -55,7 +60,7 @@ module Stoplight
           # @param exception [StandardError]
           # @return [void]
           def record_failure(exception)
-            current_time = self.current_time
+            current_time = clock.current_time
             failure = Domain::Failure.from_error(exception, time: current_time)
 
             mutex.synchronize do
@@ -73,8 +78,6 @@ module Stoplight
               self.metrics = DataStore::Memory::Metrics.new
             end
           end
-
-          private def current_time = Time.now
         end
       end
     end

--- a/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Memory
+        class UnboundedMetrics < Domain::Storage::Metrics
+          # @!attribute metrics
+          #   @return [Stoplight::Infrastructure::DataStore::Memory::Metrics]
+          private attr_accessor :metrics
+
+          # @!attribute mutex
+          #   @return [Mutex]
+          private attr_reader :mutex
+
+          def initialize
+            @mutex = Mutex.new
+            @metrics = DataStore::Memory::Metrics.new
+          end
+
+          # Get metrics for the current light
+          #
+          # @return [Stoplight::Domain::Metrics]
+          def metrics_snapshot
+            mutex.synchronize do
+              Domain::Metrics.new(
+                errors: nil,
+                successes: nil,
+                consecutive_errors: metrics.consecutive_errors.to_i,
+                consecutive_successes: metrics.consecutive_successes.to_i,
+                last_error: metrics.last_error,
+                last_success_at: metrics.last_success_at
+              )
+            end
+          end
+
+          # Records successful circuit breaker execution
+          #
+          # @return [void]
+          def record_success
+            current_time = self.current_time
+
+            mutex.synchronize do
+              if metrics.last_success_at.nil? || current_time > metrics.last_success_at
+                metrics.last_success_at = current_time
+              end
+
+              metrics.consecutive_errors = 0
+              metrics.consecutive_successes += 1
+            end
+          end
+
+          # Records failed circuit breaker execution
+          #
+          # @param exception [StandardError]
+          # @return [void]
+          def record_failure(exception)
+            current_time = self.current_time
+            failure = Domain::Failure.from_error(exception, time: current_time)
+
+            mutex.synchronize do
+              if metrics.last_error_at.nil? || failure.occurred_at > metrics.last_error_at
+                metrics.last_error = failure
+              end
+
+              metrics.consecutive_errors += 1
+              metrics.consecutive_successes = 0
+            end
+          end
+
+          def clear
+            mutex.synchronize do
+              self.metrics = DataStore::Memory::Metrics.new
+            end
+          end
+
+          private def current_time = Time.now
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
@@ -43,7 +43,7 @@ module Stoplight
           # @return [Stoplight::Domain::Metrics]
           def metrics_snapshot
             mutex.synchronize do
-              Domain::Metrics.new(
+              Domain::MetricsSnapshot.new(
                 errors: nil,
                 successes: nil,
                 consecutive_errors: metrics.consecutive_errors.to_i,
@@ -77,9 +77,10 @@ module Stoplight
           def record_failure(exception)
             current_time = clock.current_time
             failure = Domain::Failure.from_error(exception, time: current_time)
+            last_error_at = metrics.last_error_at
 
             mutex.synchronize do
-              if metrics.last_error_at.nil? || failure.occurred_at > metrics.last_error_at
+              if last_error_at.nil? || failure.occurred_at > last_error_at
                 metrics.last_error = failure
               end
 

--- a/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
@@ -4,6 +4,21 @@ module Stoplight
   module Infrastructure
     module Storage
       module Memory
+        # Thread-safe metrics storage for consecutive-error light strategies.
+        #
+        # Unlike +WindowMetrics+, this class does not track event counts within
+        # a time window. It only maintains:
+        # - Consecutive success/failure counters (reset on opposite outcome)
+        # - Most recent error with timestamp
+        # - Most recent success timestamp
+        #
+        # This is appropriate for circuit breakers using threshold-based strategies
+        # (e.g., "open after 5 consecutive failures") rather than rate-based
+        # strategies (e.g., "open when error rate exceeds 50%").
+        #
+        # @note The +#errors+ and +#successes+ fields in the returned +Stoplight::Domain::Metrics+
+        #   are always +nil+ since totals aren't tracked.
+        #
         class UnboundedMetrics < Domain::Storage::Metrics
           # @!attribute metrics
           #   @return [Stoplight::Infrastructure::DataStore::Memory::Metrics]

--- a/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/unbounded_metrics.rb
@@ -20,22 +20,18 @@ module Stoplight
         #   are always +nil+ since totals aren't tracked.
         #
         class UnboundedMetrics < Domain::Storage::Metrics
-          # @!attribute metrics
-          #   @return [Stoplight::Infrastructure::DataStore::Memory::Metrics]
-          private attr_accessor :metrics
+          private attr_accessor :consecutive_errors
+          private attr_accessor :consecutive_successes
+          private attr_accessor :last_error
+          private attr_accessor :last_success_at
 
-          # @!attribute mutex
-          #   @return [Mutex]
           private attr_reader :mutex
-
-          # @!attribute clock
-          #   @return [Stoplight::Domain::Clock]
           private attr_reader :clock
 
           def initialize(clock:)
+            initialize_metrics
             @clock = clock
             @mutex = Mutex.new
-            @metrics = DataStore::Memory::Metrics.new
           end
 
           # Get metrics for the current light
@@ -46,10 +42,10 @@ module Stoplight
               Domain::MetricsSnapshot.new(
                 errors: nil,
                 successes: nil,
-                consecutive_errors: metrics.consecutive_errors.to_i,
-                consecutive_successes: metrics.consecutive_successes.to_i,
-                last_error: metrics.last_error,
-                last_success_at: metrics.last_success_at
+                consecutive_errors: consecutive_errors.to_i,
+                consecutive_successes: consecutive_successes.to_i,
+                last_error: last_error,
+                last_success_at: last_success_at
               )
             end
           end
@@ -61,12 +57,12 @@ module Stoplight
             current_time = clock.current_time
 
             mutex.synchronize do
-              if metrics.last_success_at.nil? || current_time > metrics.last_success_at
-                metrics.last_success_at = current_time
+              if last_success_at.nil? || current_time > last_success_at
+                self.last_success_at = current_time
               end
 
-              metrics.consecutive_errors = 0
-              metrics.consecutive_successes += 1
+              self.consecutive_errors = 0
+              self.consecutive_successes += 1
             end
           end
 
@@ -77,22 +73,33 @@ module Stoplight
           def record_failure(exception)
             current_time = clock.current_time
             failure = Domain::Failure.from_error(exception, time: current_time)
-            last_error_at = metrics.last_error_at
+            last_error_at = self.last_error_at
 
             mutex.synchronize do
               if last_error_at.nil? || failure.occurred_at > last_error_at
-                metrics.last_error = failure
+                self.last_error = failure
               end
 
-              metrics.consecutive_errors += 1
-              metrics.consecutive_successes = 0
+              self.consecutive_errors += 1
+              self.consecutive_successes = 0
             end
           end
 
           def clear
             mutex.synchronize do
-              self.metrics = DataStore::Memory::Metrics.new
+              initialize_metrics
             end
+          end
+
+          private def initialize_metrics
+            @consecutive_errors = 0
+            @consecutive_successes = 0
+            @last_error = nil
+            @last_success_at = nil
+          end
+
+          private def last_error_at
+            last_error&.occurred_at
           end
         end
       end

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
@@ -4,6 +4,55 @@ module Stoplight
   module Infrastructure
     module Storage
       module Redis
+        # Distributed metrics storage for consecutive-error light strategies.
+        #
+        # This class provides a lightweight alternative to +WindowMetrics+ for circuit
+        # breakers that don't need time-windowed rate calculations. It tracks only:
+        # - Consecutive success/failure counters (reset on opposite outcome)
+        # - Most recent error with timestamp and serialized details
+        # - Most recent success timestamp
+        #
+        # == Storage Structure
+        #
+        # All data is stored in a single Redis hash:
+        #   stoplight:{version}:{system}:{light}:metrics
+        #
+        # Hash fields:
+        # - +last_success_at+: Unix timestamp (float) of most recent success
+        # - +last_error_at+: Unix timestamp (float) of most recent failure
+        # - +last_error_json+: Serialized {Domain::Failure} for error details
+        # - +consecutive_successes+: Integer counter, reset to 0 on failure
+        # - +consecutive_errors+: Integer counter, reset to 0 on success
+        #
+        # == Performance Characteristics
+        #
+        # This implementation is optimized for minimal Redis overhead:
+        # - Single hash key per circuit (vs. multiple ZSETs for +WindowMetrics+)
+        # - O(1) reads and writes
+        # - No time-range queries or bucket management
+        # - Low memory footprint
+        #
+        # == Atomicity
+        #
+        # Record operations use Lua scripts to ensure atomic read-modify-write:
+        # - Consecutive counters are incremented and reset in one round-trip
+        # - "Last" timestamps only update if the new event is more recent,
+        #   preventing out-of-order writes from corrupting state
+        #
+        # == When to Use
+        #
+        # Choose UnboundedMetrics when your circuit breaker strategy is based on
+        # consecutive failures (e.g., "open after 5 failures in a row"). Choose
+        # {WindowMetrics} when you need error rate calculations (e.g., "open when
+        # error rate exceeds 50% over 5 minutes").
+        #
+        # @note The +errors+ and +successes+ fields in the returned +Stoplight::Domain::Metrics+
+        #   are always +nil+ since this class doesn't track windowed totals.
+        #
+        # @note The metrics hash TTL is refreshed on every write operation. Circuits
+        #   with no activity will have their metrics expire, which is generally
+        #   desirable for ephemeral or decommissioned lights.
+        #
         class UnboundedMetrics < Metrics
           # @!attribute redis
           #   @return [::Redis | ConnectionPool<::Redis>]
@@ -25,7 +74,7 @@ module Stoplight
             @clock = clock
             @scripting = scripting
             @redis = redis
-            @metrics_key = key_space.key(:metadata)
+            @metrics_key = key_space.key(:metrics)
           end
 
           # Get metrics for the current light

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Redis
+        class UnboundedMetrics < Metrics
+          # @!attribute redis
+          #   @return [::Redis | ConnectionPool<::Redis>]
+          private attr_reader :redis
+
+          # @!attribute scripting
+          #   @return [Stoplight::Infrastructure::DataStore::Redis::Scripting]
+          private attr_reader :scripting
+
+          # @!attribute metrics_key
+          #   @return [String]
+          private attr_reader :metrics_key
+
+          def initialize(redis:, scripting:, key_space:)
+            @scripting = scripting
+            @redis = redis
+            @metrics_key = key_space.key(:metadata)
+          end
+
+          # Get metrics for the current light
+          #
+          # @return [Stoplight::Domain::Metrics]
+          def metrics_snapshot
+            last_success_at, last_error_json, consecutive_errors, consecutive_successes = redis.then do |client|
+              client.hmget(
+                metrics_key,
+                "last_success_at", "last_error_json", "consecutive_errors", "consecutive_successes"
+              )
+            end
+
+            Domain::Metrics.new(
+              successes: nil, errors: nil,
+              consecutive_errors: consecutive_errors.to_i,
+              consecutive_successes: consecutive_successes.to_i,
+              last_error: deserialize_failure(last_error_json),
+              last_success_at: (Time.at(last_success_at.to_f) if last_success_at)
+            )
+          end
+
+          # Records successful circuit breaker execution
+          #
+          # @return [void]
+          def record_success
+            timestamp = current_time.to_f
+
+            scripting.call(
+              :"unbounded_metrics/record_success",
+              args: [timestamp, metadata_ttl],
+              keys: [metrics_key]
+            )
+          end
+
+          # Records failed circuit breaker execution
+          #
+          # @param exception [StandardError]
+          # @return [void]
+          def record_failure(exception)
+            timestamp = current_time.to_f
+
+            scripting.call(
+              :"unbounded_metrics/record_failure",
+              args: [timestamp, serialize_exception(exception, timestamp:), metadata_ttl],
+              keys: [metrics_key]
+            )
+          end
+
+          def clear
+            redis.with do |client|
+              client.hdel(metrics_key, "last_success_at", "last_error_json", "consecutive_errors", "consecutive_successes")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
@@ -88,7 +88,7 @@ module Stoplight
               )
             end
 
-            Domain::Metrics.new(
+            Domain::MetricsSnapshot.new(
               successes: nil, errors: nil,
               consecutive_errors: consecutive_errors.to_i,
               consecutive_successes: consecutive_successes.to_i,

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics.rb
@@ -17,7 +17,12 @@ module Stoplight
           #   @return [String]
           private attr_reader :metrics_key
 
-          def initialize(redis:, scripting:, key_space:)
+          # @!attribute clock
+          #   @return [Stoplight::Domain::Clock]
+          private attr_reader :clock
+
+          def initialize(redis:, scripting:, key_space:, clock:)
+            @clock = clock
             @scripting = scripting
             @redis = redis
             @metrics_key = key_space.key(:metadata)
@@ -27,7 +32,7 @@ module Stoplight
           #
           # @return [Stoplight::Domain::Metrics]
           def metrics_snapshot
-            last_success_at, last_error_json, consecutive_errors, consecutive_successes = redis.then do |client|
+            last_success_at, last_error_json, consecutive_errors, consecutive_successes = redis.with do |client|
               client.hmget(
                 metrics_key,
                 "last_success_at", "last_error_json", "consecutive_errors", "consecutive_successes"
@@ -39,7 +44,7 @@ module Stoplight
               consecutive_errors: consecutive_errors.to_i,
               consecutive_successes: consecutive_successes.to_i,
               last_error: deserialize_failure(last_error_json),
-              last_success_at: (Time.at(last_success_at.to_f) if last_success_at)
+              last_success_at: (clock.at(last_success_at.to_f) if last_success_at)
             )
           end
 
@@ -47,11 +52,11 @@ module Stoplight
           #
           # @return [void]
           def record_success
-            timestamp = current_time.to_f
+            timestamp = clock.current_time.to_f
 
             scripting.call(
               :"unbounded_metrics/record_success",
-              args: [timestamp, metadata_ttl],
+              args: [timestamp, metrics_ttl],
               keys: [metrics_key]
             )
           end
@@ -61,11 +66,11 @@ module Stoplight
           # @param exception [StandardError]
           # @return [void]
           def record_failure(exception)
-            timestamp = current_time.to_f
+            timestamp = clock.current_time.to_f
 
             scripting.call(
               :"unbounded_metrics/record_failure",
-              args: [timestamp, serialize_exception(exception, timestamp:), metadata_ttl],
+              args: [timestamp, serialize_exception(exception, timestamp:), metrics_ttl],
               keys: [metrics_key]
             )
           end

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_failure.lua
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_failure.lua
@@ -1,0 +1,28 @@
+local failure_ts = tonumber(ARGV[1])
+local failure_json = ARGV[2]
+local metadata_ttl = tonumber(ARGV[3])
+
+local metadata_key = KEYS[1]
+
+-- Update metadata
+local meta = redis.call('HMGET', metadata_key, 'last_error_at', 'consecutive_errors')
+local prev_failure_ts = tonumber(meta[1])
+local prev_consecutive_errors = tonumber(meta[2])
+
+if not prev_failure_ts or failure_ts > prev_failure_ts then
+  redis.call(
+    'HSET', metadata_key,
+    'last_error_at', failure_ts,
+    'last_error_json', failure_json,
+    'consecutive_errors', (prev_consecutive_errors or 0) + 1,
+    'consecutive_successes', 0
+  )
+else
+  redis.call(
+    'HSET', metadata_key,
+    'consecutive_errors', (prev_consecutive_errors or 0) + 1,
+    'consecutive_successes', 0
+  )
+end
+
+redis.call('EXPIRE', metadata_key, metadata_ttl)

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_failure.lua
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_failure.lua
@@ -1,17 +1,17 @@
 local failure_ts = tonumber(ARGV[1])
 local failure_json = ARGV[2]
-local metadata_ttl = tonumber(ARGV[3])
+local metrics_ttl = tonumber(ARGV[3])
 
-local metadata_key = KEYS[1]
+local metrics_key = KEYS[1]
 
 -- Update metadata
-local meta = redis.call('HMGET', metadata_key, 'last_error_at', 'consecutive_errors')
+local meta = redis.call('HMGET', metrics_key, 'last_error_at', 'consecutive_errors')
 local prev_failure_ts = tonumber(meta[1])
 local prev_consecutive_errors = tonumber(meta[2])
 
 if not prev_failure_ts or failure_ts > prev_failure_ts then
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'last_error_at', failure_ts,
     'last_error_json', failure_json,
     'consecutive_errors', (prev_consecutive_errors or 0) + 1,
@@ -19,10 +19,10 @@ if not prev_failure_ts or failure_ts > prev_failure_ts then
   )
 else
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'consecutive_errors', (prev_consecutive_errors or 0) + 1,
     'consecutive_successes', 0
   )
 end
 
-redis.call('EXPIRE', metadata_key, metadata_ttl)
+redis.call('EXPIRE', metrics_key, metrics_ttl)

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_success.lua
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_success.lua
@@ -1,26 +1,26 @@
 local request_ts = tonumber(ARGV[1])
-local metadata_ttl = tonumber(ARGV[2])
+local metrics_ttl = tonumber(ARGV[2])
 
-local metadata_key = KEYS[1]
+local metrics_key = KEYS[1]
 
 -- Update metadata
-local meta = redis.call('HMGET', metadata_key, 'last_success_at', 'consecutive_successes')
+local meta = redis.call('HMGET', metrics_key, 'last_success_at', 'consecutive_successes')
 local prev_success_ts = tonumber(meta[1])
 local prev_consecutive_successes = tonumber(meta[2])
 
 if not prev_success_ts or request_ts > prev_success_ts then
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'last_success_at', request_ts,
     'consecutive_errors', 0,
     'consecutive_successes', (prev_consecutive_successes or 0) + 1
   )
 else
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'consecutive_errors', 0,
     'consecutive_successes', (prev_consecutive_successes or 0) + 1
   )
 end
 
-redis.call('EXPIRE', metadata_key, metadata_ttl)
+redis.call('EXPIRE', metrics_key, metrics_ttl)

--- a/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_success.lua
+++ b/lib/stoplight/infrastructure/storage/redis/unbounded_metrics/record_success.lua
@@ -1,0 +1,26 @@
+local request_ts = tonumber(ARGV[1])
+local metadata_ttl = tonumber(ARGV[2])
+
+local metadata_key = KEYS[1]
+
+-- Update metadata
+local meta = redis.call('HMGET', metadata_key, 'last_success_at', 'consecutive_successes')
+local prev_success_ts = tonumber(meta[1])
+local prev_consecutive_successes = tonumber(meta[2])
+
+if not prev_success_ts or request_ts > prev_success_ts then
+  redis.call(
+    'HSET', metadata_key,
+    'last_success_at', request_ts,
+    'consecutive_errors', 0,
+    'consecutive_successes', (prev_consecutive_successes or 0) + 1
+  )
+else
+  redis.call(
+    'HSET', metadata_key,
+    'consecutive_errors', 0,
+    'consecutive_successes', (prev_consecutive_successes or 0) + 1
+  )
+end
+
+redis.call('EXPIRE', metadata_key, metadata_ttl)

--- a/lib/stoplight/wiring/system/light_builder.rb
+++ b/lib/stoplight/wiring/system/light_builder.rb
@@ -73,7 +73,16 @@ module Stoplight
           if config.window_size
             Infrastructure::Storage::CompatibilityMetrics.new(config:, data_store:)
           else
-            Infrastructure::Storage::Redis::UnboundedMetrics.new(redis:, scripting: storage_scripting, key_space:)
+            Infrastructure::Storage::FailSafe::Metrics.new(
+              error_notifier:,
+              primary_store: Infrastructure::Storage::Redis::UnboundedMetrics.new(
+                redis:,
+                scripting: storage_scripting,
+                key_space:
+              ),
+              failover_store: Infrastructure::Storage::Memory::UnboundedMetrics.new,
+              circuit_breaker: failover_system.light("redis")
+            )
           end
         end
 

--- a/lib/stoplight/wiring/system/light_builder.rb
+++ b/lib/stoplight/wiring/system/light_builder.rb
@@ -59,9 +59,8 @@ module Stoplight
           end
         end
 
-        private def redis = data_store_config
         private def metrics_store
-          case data_store_config
+          @metrics_store ||= case data_store_config
           in DataStore::Redis
             redis_metrics_store
           in DataStore::Memory

--- a/lib/stoplight/wiring/system/light_builder.rb
+++ b/lib/stoplight/wiring/system/light_builder.rb
@@ -76,11 +76,12 @@ module Stoplight
             Infrastructure::Storage::FailSafe::Metrics.new(
               error_notifier:,
               primary_store: Infrastructure::Storage::Redis::UnboundedMetrics.new(
+                clock:,
                 redis:,
                 scripting: storage_scripting,
                 key_space:
               ),
-              failover_store: Infrastructure::Storage::Memory::UnboundedMetrics.new,
+              failover_store: Infrastructure::Storage::Memory::UnboundedMetrics.new(clock:),
               circuit_breaker: failover_system.light("redis")
             )
           end
@@ -90,7 +91,7 @@ module Stoplight
           if config.window_size
             Infrastructure::Storage::CompatibilityMetrics.new(config:, data_store:)
           else
-            Infrastructure::Storage::Memory::UnboundedMetrics.new
+            Infrastructure::Storage::Memory::UnboundedMetrics.new(clock:)
           end
         end
 

--- a/lib/stoplight/wiring/system/light_builder.rb
+++ b/lib/stoplight/wiring/system/light_builder.rb
@@ -60,6 +60,32 @@ module Stoplight
         end
 
         private def redis = data_store_config
+        private def metrics_store
+          case data_store_config
+          in DataStore::Redis
+            redis_metrics_store
+          in DataStore::Memory
+            memory_metrics_store
+          end
+        end
+
+        private def redis_metrics_store
+          if config.window_size
+            Infrastructure::Storage::CompatibilityMetrics.new(config:, data_store:)
+          else
+            Infrastructure::Storage::Redis::UnboundedMetrics.new(redis:, scripting: storage_scripting, key_space:)
+          end
+        end
+
+        private def memory_metrics_store
+          if config.window_size
+            Infrastructure::Storage::CompatibilityMetrics.new(config:, data_store:)
+          else
+            Infrastructure::Storage::Memory::UnboundedMetrics.new
+          end
+        end
+
+        private def redis = data_store_config.redis
         private def storage_scripting = Infrastructure::Storage::Redis::Scripting.new(redis:)
         private def failover_system = @failover_system ||= Stoplight.__stoplight__system("failover-#{system.name}")
       end

--- a/sig/stoplight/domain/failure.rbs
+++ b/sig/stoplight/domain/failure.rbs
@@ -4,9 +4,9 @@ module Stoplight
       attr_reader error_class: String
       attr_reader error_message: String
       attr_reader time: Time
-      attr_reader occured_at: String
+      alias occurred_at time
 
-      def self.from_error: (StandardError error, time: Time) -> Failure
+      def self.from_error: (StandardError error, time: Time) -> instance
 
       def initialize: (String error_class, String error_message, Time time) -> void
 

--- a/sig/stoplight/domain/metrics_snapshot.rbs
+++ b/sig/stoplight/domain/metrics_snapshot.rbs
@@ -1,24 +1,33 @@
 module Stoplight
   module Domain
     class MetricsSnapshot < Data
-      def successes: -> Integer?
-      def successes!: -> Integer
-      def errors!: -> Integer
-      def errors: -> Integer?
-      def consecutive_errors: -> Integer
-      def consecutive_successes: -> Integer
-      def last_error: -> Failure?
-      def last_success_at: -> Time?
+      attr_reader successes: Integer?
+      attr_reader errors: Integer?
+      attr_reader consecutive_errors: Integer
+      attr_reader consecutive_successes: Integer
+      attr_reader last_error: Failure?
+      attr_reader last_success_at: Time?
+
+      def self.new: (
+          successes: Integer?,
+          errors: Integer?,
+          consecutive_errors: Integer,
+          consecutive_successes: Integer,
+          last_error: Failure?,
+          last_success_at: Time?
+        ) -> instance
 
       def initialize: (
-        successes: Integer?,
-        errors: Integer?,
-        consecutive_errors: Integer,
-        consecutive_successes: Integer,
-        last_error: Failure?,
-        last_success_at: Time?
-      ) -> void
+          successes: Integer?,
+          errors: Integer?,
+          consecutive_errors: Integer,
+          consecutive_successes: Integer,
+          last_error: Failure?,
+          last_success_at: Time?
+        ) -> void
 
+      def errors!: -> Integer
+      def successes!: -> Integer
       def error_rate: () -> Float?
 
       def requests: () -> Integer?

--- a/sig/stoplight/infrastructure/storage/memory/unbounded_metrics.rbs
+++ b/sig/stoplight/infrastructure/storage/memory/unbounded_metrics.rbs
@@ -3,11 +3,19 @@ module Stoplight
     module Storage
       module Memory
         class UnboundedMetrics < Domain::Storage::Metrics
-          attr_accessor metrics: DataStore::Memory::Metrics
+          attr_accessor consecutive_errors: Integer
+          attr_accessor consecutive_successes: Integer
+          attr_accessor last_error: Domain::Failure?
+          attr_accessor last_success_at: Time?
+
           attr_reader mutex: Mutex
           attr_reader clock: Domain::Clock
 
           def initialize: (clock: Domain::Clock) -> void
+
+          def last_error_at: -> Time?
+
+          private def initialize_metrics: -> void
         end
       end
     end

--- a/sig/stoplight/infrastructure/storage/memory/unbounded_metrics.rbs
+++ b/sig/stoplight/infrastructure/storage/memory/unbounded_metrics.rbs
@@ -1,0 +1,15 @@
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Memory
+        class UnboundedMetrics < Domain::Storage::Metrics
+          attr_accessor metrics: DataStore::Memory::Metrics
+          attr_reader mutex: Mutex
+          attr_reader clock: Domain::Clock
+
+          def initialize: (clock: Domain::Clock) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/stoplight/infrastructure/storage/redis/unbounded_metrics.rbs
+++ b/sig/stoplight/infrastructure/storage/redis/unbounded_metrics.rbs
@@ -1,0 +1,21 @@
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Redis
+        class UnboundedMetrics < Redis::Metrics
+          attr_reader redis: redis
+          attr_reader scripting: Scripting
+          attr_reader metrics_key: String
+          attr_reader clock: Domain::Clock
+
+          def initialize: (
+            redis: redis,
+            clock: Domain::Clock,
+            scripting: Scripting,
+            key_space: KeySpace,
+          ) -> void
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/infrastructure/storage/memory/unbounded_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/memory/unbounded_metrics_spec.rb
@@ -3,7 +3,9 @@
 require_relative "../../data_store/metrics_snapshot"
 
 RSpec.describe Stoplight::Infrastructure::Storage::Memory::UnboundedMetrics do
-  subject(:unbounded_metrics) { described_class.new }
+  subject(:unbounded_metrics) { described_class.new(clock:) }
+
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
 
   it_behaves_like "a metrics snapshot" do
     def metrics_snapshot = unbounded_metrics.metrics_snapshot

--- a/spec/unit/stoplight/infrastructure/storage/memory/unbounded_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/memory/unbounded_metrics_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../../data_store/metrics_snapshot"
+
+RSpec.describe Stoplight::Infrastructure::Storage::Memory::UnboundedMetrics do
+  subject(:unbounded_metrics) { described_class.new }
+
+  it_behaves_like "a metrics snapshot" do
+    def metrics_snapshot = unbounded_metrics.metrics_snapshot
+    def record_failure(error) = unbounded_metrics.record_failure(error)
+    def record_success = unbounded_metrics.record_success
+  end
+end

--- a/spec/unit/stoplight/infrastructure/storage/redis/unbounded_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/redis/unbounded_metrics_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "../../data_store/metrics_snapshot"
+
+RSpec.describe Stoplight::Infrastructure::Storage::Redis::UnboundedMetrics, :redis do
+  subject(:unbounded_metrics) { described_class.new(scripting:, redis:, key_space:) }
+
+  let(:key_space) { Stoplight::Infrastructure::Storage::Redis::KeySpace.build(light_name:, system_name:) }
+  let(:scripting) { Stoplight::Infrastructure::Storage::Redis::Scripting.new(redis:) }
+
+  let(:light_name) { SecureRandom.uuid }
+  let(:system_name) { SecureRandom.uuid }
+
+  def metrics_snapshot = unbounded_metrics.metrics_snapshot
+  def record_failure(error) = unbounded_metrics.record_failure(error)
+  def record_success = unbounded_metrics.record_success
+
+  it_behaves_like "a metrics snapshot"
+end

--- a/spec/unit/stoplight/infrastructure/storage/redis/unbounded_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/redis/unbounded_metrics_spec.rb
@@ -3,8 +3,9 @@
 require_relative "../../data_store/metrics_snapshot"
 
 RSpec.describe Stoplight::Infrastructure::Storage::Redis::UnboundedMetrics, :redis do
-  subject(:unbounded_metrics) { described_class.new(scripting:, redis:, key_space:) }
+  subject(:unbounded_metrics) { described_class.new(scripting:, redis:, key_space:, clock:) }
 
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:key_space) { Stoplight::Infrastructure::Storage::Redis::KeySpace.build(light_name:, system_name:) }
   let(:scripting) { Stoplight::Infrastructure::Storage::Redis::Scripting.new(redis:) }
 

--- a/spec/unit/stoplight/infrastructure/storage/redis/unbounded_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/redis/unbounded_metrics_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Stoplight::Infrastructure::Storage::Redis::UnboundedMetrics, :red
   let(:light_name) { SecureRandom.uuid }
   let(:system_name) { SecureRandom.uuid }
 
-  def metrics_snapshot = unbounded_metrics.metrics_snapshot
-  def record_failure(error) = unbounded_metrics.record_failure(error)
-  def record_success = unbounded_metrics.record_success
-
-  it_behaves_like "a metrics snapshot"
+  it_behaves_like "a metrics snapshot" do
+    def metrics_snapshot = unbounded_metrics.metrics_snapshot
+    def record_failure(error) = unbounded_metrics.record_failure(error)
+    def record_success = unbounded_metrics.record_success
+  end
 end


### PR DESCRIPTION
Extracts metrics tracking from DataStore into dedicated per-circuit storage instances, continuing the storage abstraction separation.

This PR applies the same pattern we used for recovery locks and state to metrics, specifically for circuits without `window_size` (unbounded metrics tracking consecutive successes/errors and last timestamps).

**Before:** DataStore handled metrics for ALL circuits

```ruby
data_store.record_success(config)
data_store.record_failure(config, error)
```

**After:** Each circuit has its own metrics storage instance

```ruby
metrics_store = Redis::UnboundedMetrics.new(redis:, scripting:, key_space:)
metrics_store.record_success        # No config needed - knows its circuit
metrics_store.record_failure(error)
```

Circuits with `window_size` still use `CompatibilityMetrics` adapter until windowed metrics storage is implemented.