### PR TITLE
Add Clock abstraction for centralized time handling

### DIFF
--- a/lib/stoplight/domain/clock.rb
+++ b/lib/stoplight/domain/clock.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    # Abstract wall-clock interface for time-dependent operations.
+    #
+    # Provides a centralized definition of how Stoplight obtains and
+    # interprets time. All time-dependent components should use this
+    # interface rather than calling Time methods directly, ensuring
+    # consistent time handling across the library.
+    #
+    # @abstract Subclass and override {#current_time} and {#at} to implement
+    #   a custom clock.
+    class Clock
+      # Returns the current time.
+      #
+      # @return [Time] current wall-clock time
+      def current_time = raise NotImplementedError
+
+      # Converts a Unix timestamp to a Time object.
+      #
+      # @param timestamp [Integer, Float] Unix timestamp (seconds since epoch)
+      # @return [Time] time object representing the given timestamp
+      # @return [Time]
+      def at(timestamp) = raise NotImplementedError
+    end
+  end
+end

--- a/lib/stoplight/domain/failure.rb
+++ b/lib/stoplight/domain/failure.rb
@@ -16,7 +16,7 @@ module Stoplight
 
       # @param error [Exception]
       # @return (see #initialize)
-      def self.from_error(error, time: Time.now)
+      def self.from_error(error, time:)
         new(error.class.name, error.message, time)
       end
 

--- a/lib/stoplight/infrastructure/data_store/memory.rb
+++ b/lib/stoplight/infrastructure/data_store/memory.rb
@@ -16,11 +16,16 @@ module Stoplight
         #   @api private
         private attr_reader :recovery_lock_store
 
+        # @!attribute clock
+        #   @return [Stoplight::Domain::Clock]
+        private attr_reader :clock
+
         # @param recovery_lock_store [Stoplight::Infrastructure::DataStore::Memory::RecoveryLockStore]
-        def initialize(recovery_lock_store:)
+        def initialize(recovery_lock_store:, clock:)
+          @clock = clock
           @recovery_lock_store = recovery_lock_store
-          @errors = Hash.new { |errors, light_name| errors[light_name] = SlidingWindow.new }
-          @successes = Hash.new { |successes, light_name| successes[light_name] = SlidingWindow.new }
+          @errors = Hash.new { |errors, light_name| errors[light_name] = SlidingWindow.new(clock:) }
+          @successes = Hash.new { |successes, light_name| successes[light_name] = SlidingWindow.new(clock:) }
           @metrics = Hash.new { |metrics, light_name| metrics[light_name] = Metrics.new }
 
           @recovery_metrics = Hash.new { |metrics, light_name| metrics[light_name] = Metrics.new }
@@ -124,8 +129,8 @@ module Stoplight
           light_name = config.name
           synchronize do
             if config.window_size
-              @errors[light_name] = SlidingWindow.new
-              @successes[light_name] = SlidingWindow.new
+              @errors[light_name] = SlidingWindow.new(clock:)
+              @successes[light_name] = SlidingWindow.new(clock:)
             end
             @metrics[light_name] = Metrics.new
           end

--- a/lib/stoplight/infrastructure/data_store/memory.rb
+++ b/lib/stoplight/infrastructure/data_store/memory.rb
@@ -46,7 +46,7 @@ module Stoplight
           light_name = config.name
 
           synchronize do
-            current_time = self.current_time
+            current_time = clock.current_time
             window_start = if config.window_size
               (current_time - config.window_size)
             else
@@ -91,7 +91,7 @@ module Stoplight
         # @return [Stoplight::Domain::StateSnapshot]
         def get_state_snapshot(config)
           time, state = synchronize do
-            [current_time, @states[config.name]]
+            [clock.current_time, @states[config.name]]
           end
 
           Domain::StateSnapshot.new(
@@ -107,7 +107,7 @@ module Stoplight
         # @param exception [Exception]
         # @return [void]
         def record_failure(config, exception)
-          current_time = self.current_time
+          current_time = clock.current_time
           light_name = config.name
           failure = Domain::Failure.from_error(exception, time: current_time)
 
@@ -146,7 +146,7 @@ module Stoplight
         # @return [void]
         def record_success(config)
           light_name = config.name
-          current_time = self.current_time
+          current_time = clock.current_time
 
           synchronize do
             @successes[light_name].increment if config.window_size
@@ -167,7 +167,7 @@ module Stoplight
         # @return [void]
         def record_recovery_probe_failure(config, exception)
           light_name = config.name
-          current_time = self.current_time
+          current_time = clock.current_time
           failure = Domain::Failure.from_error(exception, time: current_time)
 
           synchronize do
@@ -186,7 +186,7 @@ module Stoplight
         # @return [void]
         def record_recovery_probe_success(config)
           light_name = config.name
-          current_time = self.current_time
+          current_time = clock.current_time
 
           synchronize do
             metrics = @recovery_metrics[light_name]
@@ -266,7 +266,7 @@ module Stoplight
         # @return [Boolean] true if this is the first instance to detect this transition
         private def transition_to_green(config)
           light_name = config.name
-          current_time = self.current_time
+          current_time = clock.current_time
 
           synchronize do
             state = @states[light_name]
@@ -289,7 +289,7 @@ module Stoplight
         # @return [Boolean] true if this is the first instance to detect this transition
         private def transition_to_yellow(config)
           light_name = config.name
-          current_time = self.current_time
+          current_time = clock.current_time
 
           synchronize do
             state = @states[light_name]
@@ -314,7 +314,7 @@ module Stoplight
         # @return [Boolean] true if this is the first instance to detect this transition
         private def transition_to_red(config)
           light_name = config.name
-          current_time = self.current_time
+          current_time = clock.current_time
           recovery_scheduled_after = current_time + config.cool_off_time
 
           synchronize do
@@ -332,10 +332,6 @@ module Stoplight
               true
             end
           end
-        end
-
-        private def current_time
-          Time.now
         end
       end
     end

--- a/lib/stoplight/infrastructure/data_store/memory.rb
+++ b/lib/stoplight/infrastructure/data_store/memory.rb
@@ -21,6 +21,7 @@ module Stoplight
         private attr_reader :clock
 
         # @param recovery_lock_store [Stoplight::Infrastructure::DataStore::Memory::RecoveryLockStore]
+        # @param clock [Stoplight::Domain::Clock]
         def initialize(recovery_lock_store:, clock:)
           @clock = clock
           @recovery_lock_store = recovery_lock_store

--- a/lib/stoplight/infrastructure/data_store/memory/sliding_window.rb
+++ b/lib/stoplight/infrastructure/data_store/memory/sliding_window.rb
@@ -25,9 +25,15 @@ module Stoplight
           #   @return [Integer] The running sum of all increments in the current window
           private attr_accessor :running_sum
 
-          def initialize
+          # @!attribute clock
+          #   @return [Stoplight::Domain::Clock]
+          private attr_reader :clock
+
+          # @param clock [Stoplight::Domain::Clock]
+          def initialize(clock:)
             @buckets = Hash.new { |buckets, bucket| buckets[bucket] = 0 }
             @running_sum = 0
+            @clock = clock
           end
 
           # Increment the count at a given timestamp
@@ -58,15 +64,11 @@ module Stoplight
           end
 
           private def current_bucket
-            bucket_for_time(current_time)
+            bucket_for_time(clock.current_time)
           end
 
           private def bucket_for_time(time)
             time.to_i
-          end
-
-          private def current_time
-            Time.now
           end
 
           def inspect

--- a/lib/stoplight/infrastructure/data_store/redis.rb
+++ b/lib/stoplight/infrastructure/data_store/redis.rb
@@ -90,12 +90,18 @@ module Stoplight
         #   @return [Boolean]
         protected attr_reader :warn_on_clock_skew
 
+        # @!attribute clock
+        #   @return [Stoplight::Domain::Clock]
+        private attr_reader :clock
+
         # @param redis [::Redis, ConnectionPool<::Redis>]
         # @param recovery_lock_store [Stoplight::Infrastructure::DataStore::Redis::RecoveryLockStore]
         # @param warn_on_clock_skew [Boolean] (true) Whether to warn about clock skew between Redis and
         # @param scripting [Stoplight::Infrastructure::DataStore::Redis::Scripting]
+        # @param clock [Stoplight::Domain::Clock]
         #   the application server
-        def initialize(redis:, recovery_lock_store:, scripting:, warn_on_clock_skew: true)
+        def initialize(redis:, recovery_lock_store:, scripting:, clock:, warn_on_clock_skew: true)
+          @clock = clock
           @warn_on_clock_skew = warn_on_clock_skew
           @redis = redis
           @recovery_lock_store = recovery_lock_store
@@ -121,7 +127,7 @@ module Stoplight
         def get_metrics(config)
           config.name
 
-          window_end_ts = current_time.to_f
+          window_end_ts = clock.current_time.to_f
           window_start_ts = window_end_ts - config.window_size.to_i
 
           if config.window_size
@@ -155,7 +161,7 @@ module Stoplight
             consecutive_errors:,
             consecutive_successes:,
             last_error: deserialize_failure(last_error_json),
-            last_success_at: (Time.at(last_success_at.to_f) if last_success_at)
+            last_success_at: (clock.at(last_success_at.to_f) if last_success_at)
           )
         end
 
@@ -174,7 +180,7 @@ module Stoplight
             consecutive_errors: consecutive_errors.to_i,
             consecutive_successes: consecutive_successes.to_i,
             last_error: deserialize_failure(last_error_json),
-            last_success_at: (Time.at(last_success_at.to_f) if last_success_at)
+            last_success_at: (clock.at(last_success_at.to_f) if last_success_at)
           )
         end
 
@@ -190,17 +196,17 @@ module Stoplight
           recovery_started_at = recovery_started_at_raw&.to_f
 
           Domain::StateSnapshot.new(
-            breached_at: (Time.at(breached_at) if breached_at),
+            breached_at: (clock.at(breached_at) if breached_at),
             locked_state: locked_state || Domain::State::UNLOCKED,
-            recovery_scheduled_after: (Time.at(recovery_scheduled_after) if recovery_scheduled_after),
-            recovery_started_at: (Time.at(recovery_started_at) if recovery_started_at),
-            time: current_time
+            recovery_scheduled_after: (clock.at(recovery_scheduled_after) if recovery_scheduled_after),
+            recovery_started_at: (clock.at(recovery_started_at) if recovery_started_at),
+            time: clock.current_time
           )
         end
 
         def clear_metrics(config)
           if config.window_size
-            window_end_ts = current_time.to_i
+            window_end_ts = clock.current_time.to_i
             @redis.with do |client|
               client.multi do |tx|
                 tx.unlink(
@@ -223,16 +229,16 @@ module Stoplight
           end
         end
 
-        private def state_snapshot_from_hash(data, time: current_time)
+        private def state_snapshot_from_hash(data, time: clock.current_time)
           breached_at = data[:breached_at]&.to_f
           recovery_scheduled_after = data[:recovery_scheduled_after]&.to_f
           recovery_started_at = data[:recovery_started_at]&.to_f
 
           Domain::StateSnapshot.new(
-            breached_at: (Time.at(breached_at) if breached_at),
+            breached_at: (clock.at(breached_at) if breached_at),
             locked_state: data[:locked_state] || Domain::State::UNLOCKED,
-            recovery_scheduled_after: (Time.at(recovery_scheduled_after) if recovery_scheduled_after),
-            recovery_started_at: (Time.at(recovery_started_at) if recovery_started_at),
+            recovery_scheduled_after: (clock.at(recovery_scheduled_after) if recovery_scheduled_after),
+            recovery_started_at: (clock.at(recovery_started_at) if recovery_started_at),
             time:
           )
         end
@@ -241,8 +247,8 @@ module Stoplight
         # @param exception [Exception]
         # @return [void]
         def record_failure(config, exception)
-          current_time = self.current_time
-          current_ts = current_time.to_f
+          current_time = clock.current_time
+          current_ts = clock.current_time.to_f
           failure = Domain::Failure.from_error(exception, time: current_time)
 
           scripting.call(
@@ -256,7 +262,7 @@ module Stoplight
         end
 
         def record_success(config, request_id: SecureRandom.hex(12))
-          current_ts = current_time.to_f
+          current_ts = clock.current_time.to_f
 
           scripting.call(
             :record_success,
@@ -274,8 +280,8 @@ module Stoplight
         # @param exception [Exception]
         # @return [void]
         def record_recovery_probe_failure(config, exception)
-          current_time = self.current_time
-          current_ts = current_time.to_f
+          current_time = clock.current_time
+          current_ts = clock.current_time.to_f
           failure = Domain::Failure.from_error(exception, time: current_time)
 
           scripting.call(
@@ -290,7 +296,7 @@ module Stoplight
         # @param config [Stoplight::Domain::Config] The light configuration.
         # @return [void]
         def record_recovery_probe_success(config)
-          current_ts = current_time.to_f
+          current_ts = clock.current_time.to_f
 
           scripting.call(
             :record_recovery_probe_success,
@@ -345,7 +351,7 @@ module Stoplight
         # @param config [Stoplight::Domain::Config] The light configuration
         # @return [Boolean] true if this is the first instance to detect this transition
         private def transition_to_green(config)
-          current_ts = current_time.to_f
+          current_ts = clock.current_time.to_f
           meta_key = metadata_key(config)
 
           became_green = scripting.call(
@@ -361,7 +367,7 @@ module Stoplight
         # @param config [Stoplight::Domain::Config] The light configuration
         # @return [Boolean] true if this is the first instance to detect this transition
         private def transition_to_yellow(config)
-          current_ts = current_time.to_f
+          current_ts = clock.current_time.to_f
           meta_key = metadata_key(config)
 
           became_yellow = scripting.call(
@@ -377,7 +383,7 @@ module Stoplight
         # @param config [Stoplight::Domain::Config] The light configuration
         # @return [Boolean] true if this is the first instance to detect this transition
         private def transition_to_red(config)
-          current_ts = current_time.to_f
+          current_ts = clock.current_time.to_f
           meta_key = metadata_key(config)
           recovery_scheduled_after_ts = current_ts + config.cool_off_time
 
@@ -410,7 +416,7 @@ module Stoplight
 
           error_class = error_object["class"]
           error_message = error_object["message"]
-          time = Time.at(object["time"])
+          time = clock.at(object["time"])
 
           Domain::Failure.new(error_class, error_message, time)
         end
@@ -505,7 +511,7 @@ module Stoplight
           return unless should_sample?(0.01) # 1% chance
 
           redis_seconds, _redis_millis = @redis.then(&:time)
-          app_seconds = current_time.to_i
+          app_seconds = clock.current_time.to_i
           if (redis_seconds - app_seconds).abs > SKEW_TOLERANCE
             warn("Detected clock skew between Redis and the application server. Redis time: #{redis_seconds}, Application time: #{app_seconds}. See https://github.com/bolshakov/stoplight/wiki/Clock-Skew-and-Stoplight-Reliability")
           end
@@ -513,10 +519,6 @@ module Stoplight
 
         private def should_sample?(probability)
           rand <= probability
-        end
-
-        private def current_time
-          Time.now
         end
       end
     end

--- a/lib/stoplight/infrastructure/system_clock.rb
+++ b/lib/stoplight/infrastructure/system_clock.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    # Production clock implementation using Ruby's Time class.
+    #
+    # Default clock for all Stoplight time-dependent operations including
+    # bucket calculation, window boundaries, and state transition timestamps.
+    #
+    # @see Stoplight::Domain::Clock Abstract interface
+    class SystemClock < Domain::Clock
+      # @return [Time] current system time
+      def current_time = Time.now
+
+      # @param timestamp [Integer, Float] Unix timestamp
+      # @return [Time] time at the given timestamp
+      def at(timestamp) = Time.at(timestamp)
+    end
+  end
+end

--- a/lib/stoplight/wiring/light_builder.rb
+++ b/lib/stoplight/wiring/light_builder.rb
@@ -58,6 +58,10 @@ module Stoplight
       #   @return [Stoplight::Domain::LightFactory]
       private attr_reader :factory
 
+      # @!attribute clock
+      #   @return [Stoplight::Domain::Clock]
+      private attr_reader :clock
+
       def initialize(settings)
         @notifiers = settings[:notifiers]
         @data_store_config = settings[:data_store]
@@ -66,6 +70,7 @@ module Stoplight
         @traffic_control = settings[:traffic_control]
         @config = settings[:config]
         @factory = settings[:factory]
+        @clock = Infrastructure::SystemClock.new
       end
 
       def build
@@ -161,7 +166,8 @@ module Stoplight
         in Stoplight::DataStore::Memory
           memory_registry.compute_if_absent(data_store_config.object_id) do
             Infrastructure::DataStore::Memory.new(
-              recovery_lock_store: memory_recovery_lock_store
+              recovery_lock_store: memory_recovery_lock_store,
+              clock:
             )
           end
         in Stoplight::DataStore::Redis

--- a/lib/stoplight/wiring/light_builder.rb
+++ b/lib/stoplight/wiring/light_builder.rb
@@ -173,6 +173,7 @@ module Stoplight
         in Stoplight::DataStore::Redis
           Infrastructure::DataStore::FailSafe.new(
             data_store: Stoplight::Infrastructure::DataStore::Redis.new(
+              clock:,
               redis: data_store_config.redis,
               warn_on_clock_skew: data_store_config.warn_on_clock_skew,
               recovery_lock_store: redis_recovery_lock_store,

--- a/spec/integration/infrastructure/data_store/fail_safe_spec.rb
+++ b/spec/integration/infrastructure/data_store/fail_safe_spec.rb
@@ -4,7 +4,8 @@ require "securerandom"
 
 RSpec.describe Stoplight::Infrastructure::DataStore::FailSafe do
   let(:fail_safe) { described_class.new(data_store:, error_notifier:, failover_data_store:, circuit_breaker:) }
-  let(:failover_data_store) { Stoplight::Infrastructure::DataStore::Memory.new(recovery_lock_store:) }
+  let(:failover_data_store) { Stoplight::Infrastructure::DataStore::Memory.new(recovery_lock_store:, clock:) }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:recovery_lock_store) { Stoplight::Infrastructure::DataStore::Memory::RecoveryLockStore.new }
   let(:config) { Stoplight::Domain::Config.empty.with(name:, window_size: 4, cool_off_time: 60, threshold: 3) }
   let(:name) { SecureRandom.uuid }

--- a/spec/integration/redis_backward_compatibility_spec.rb
+++ b/spec/integration/redis_backward_compatibility_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe "Redis drop-in compatibility", :redis, :freeze do
   let(:light_name) { SecureRandom.uuid }
-  let(:data_store) { Stoplight::Infrastructure::DataStore::Redis.new(redis:, recovery_lock_store:, scripting:) }
+  let(:data_store) { Stoplight::Infrastructure::DataStore::Redis.new(redis:, recovery_lock_store:, scripting:, clock:) }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:recovery_lock_store) { Stoplight::Infrastructure::DataStore::Redis::RecoveryLockStore.new(redis:, lock_timeout: 100, scripting:) }
   let(:scripting) { Stoplight::Infrastructure::DataStore::Redis::Scripting.new(redis:) }
   let(:config) { Stoplight::Domain::Config.empty.with(name: light_name, window_size: 300) }

--- a/spec/unit/stoplight/admin/lights_repository/light_spec.rb
+++ b/spec/unit/stoplight/admin/lights_repository/light_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Stoplight::Admin::LightsRepository::Light do
     )
   end
   let(:failures) { [latest_failure] }
-  let(:latest_failure) { Stoplight::Domain::Failure.from_error(latest_exception) }
+  let(:latest_failure) { Stoplight::Domain::Failure.from_error(latest_exception, time: Time.now) }
   let(:latest_exception) { StandardError.new("bang!") }
   let(:color) { "green" }
   let(:name) { "light-specs" }
@@ -85,7 +85,7 @@ RSpec.describe Stoplight::Admin::LightsRepository::Light do
     subject { light.last_check_in_words }
 
     context "when the last check was more than a second ago" do
-      let(:latest_failure) { Stoplight::Domain::Failure.from_error(StandardError.new) }
+      let(:latest_failure) { Stoplight::Domain::Failure.from_error(StandardError.new, time: Time.now) }
 
       it { is_expected.to eq("just now") }
     end

--- a/spec/unit/stoplight/admin/lights_repository_spec.rb
+++ b/spec/unit/stoplight/admin/lights_repository_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Stoplight::Admin::LightsRepository, :redis do
 
   let(:data_store) do
     Stoplight::Infrastructure::DataStore::Redis.new(
+      clock:,
       redis:,
       warn_on_clock_skew: false,
       recovery_lock_store: redis_recovery_lock_store,
@@ -18,6 +19,7 @@ RSpec.describe Stoplight::Admin::LightsRepository, :redis do
       scripting:
     )
   end
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:scripting) do
     Stoplight::Infrastructure::DataStore::Redis::Scripting.new(redis:)
   end

--- a/spec/unit/stoplight/domain/failure_spec.rb
+++ b/spec/unit/stoplight/domain/failure_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Stoplight::Domain::Failure do
   describe ".from_error" do
     it "creates a failure" do
       Timecop.freeze do
-        failure = described_class.from_error(error)
+        failure = described_class.from_error(error, time: Time.now)
         expect(failure.error_class).to eql(error_class)
         expect(failure.error_message).to eql(error_message)
         expect(failure.time.to_i).to eql(Time.new.to_i)

--- a/spec/unit/stoplight/infrastructure/data_store/fail_safe_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/fail_safe_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Stoplight::Infrastructure::DataStore::FailSafe do
       circuit_breaker: test_circuit_breaker_class.new
     )
   end
-  let(:failover_data_store) { Stoplight::Infrastructure::DataStore::Memory.new(recovery_lock_store:) }
+  let(:failover_data_store) { Stoplight::Infrastructure::DataStore::Memory.new(recovery_lock_store:, clock:) }
   let(:recovery_lock_store) { Stoplight::Infrastructure::DataStore::Memory::RecoveryLockStore.new }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:data_store) { instance_double(Stoplight::Domain::DataStore) }
   let(:config) { Stoplight::Domain::Config.empty.with(name:, window_size: 4, cool_off_time: 60, threshold: 3) }
   let(:error_notifier) { instance_double(Proc) }

--- a/spec/unit/stoplight/infrastructure/data_store/memory/sliding_window_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/memory/sliding_window_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Stoplight::Infrastructure::DataStore::Memory::SlidingWindow do
-  let(:counter) { described_class.new }
+  let(:counter) { described_class.new(clock:) }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
 
   around do |example|
     Timecop.freeze do

--- a/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/memory_spec.rb
@@ -4,8 +4,9 @@ require_relative "recovery_metrics"
 require_relative "metrics"
 
 RSpec.describe Stoplight::Infrastructure::DataStore::Memory do
-  let(:data_store) { described_class.new(recovery_lock_store:) }
+  let(:data_store) { described_class.new(recovery_lock_store:, clock:) }
   let(:recovery_lock_store) { instance_double(described_class::RecoveryLockStore) }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
 
   let(:config) { Stoplight::Domain::Config.empty.with(name:, window_size:, cool_off_time:) }
   let(:name) { ("a".."z").to_a.shuffle.join }

--- a/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/redis_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Redis, :redis do
   let(:other) { Stoplight::Domain::Failure.new("class", "message 2", Time.new) }
   let(:window_size) { 60 }
   let(:cool_off_time) { 60 }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
 
   describe ".buckets_for_window" do
     subject(:buckets) { described_class.buckets_for_window(light_name, metric:, window_end:, window_size:) }
@@ -68,7 +69,7 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Redis, :redis do
     let(:redis_mock) { instance_double(Redis) }
 
     it "does not communicate with redis on initialization" do
-      expect { described_class.new(redis: redis_mock, recovery_lock_store: nil, scripting: nil) }.not_to raise_error
+      expect { described_class.new(redis: redis_mock, recovery_lock_store: nil, scripting: nil, clock:) }.not_to raise_error
     end
   end
 
@@ -187,6 +188,7 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Redis, :redis do
   it_behaves_like Stoplight::Infrastructure::DataStore::Redis do
     let(:data_store) do
       described_class.new(
+        clock:,
         redis: connection,
         warn_on_clock_skew: warn_on_clock_skew,
         recovery_lock_store:,
@@ -199,6 +201,7 @@ RSpec.describe Stoplight::Infrastructure::DataStore::Redis, :redis do
   it_behaves_like Stoplight::Infrastructure::DataStore::Redis do
     let(:data_store) do
       described_class.new(
+        clock:,
         redis: connection,
         warn_on_clock_skew: warn_on_clock_skew,
         recovery_lock_store:,

--- a/spec/unit/stoplight/infrastructure/system_clock_spec.rb
+++ b/spec/unit/stoplight/infrastructure/system_clock_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::SystemClock do
+  subject(:clock) { described_class.new }
+
+  describe "#current_time" do
+    subject(:current_time) { clock.current_time }
+
+    around do |example|
+      Timecop.freeze { example.run }
+    end
+
+    it "returns current wall-clock time" do
+      expect(current_time).to eq(Time.now)
+    end
+  end
+
+  describe "#at" do
+    subject(:at) { clock.at(timestamp) }
+
+    context "with integer timestamp" do
+      let(:timestamp) { 1705329000 }
+
+      it "converts to Time" do
+        expect(at).to eq(Time.at(timestamp))
+      end
+    end
+
+    context "with float timestamp (sub-second precision)" do
+      let(:timestamp) { 1705329000.123456 }
+
+      it "preserves sub-second precision" do
+        expect(at.nsec).to be > 0
+      end
+    end
+
+    context "with zero timestamp (Unix epoch)" do
+      let(:timestamp) { 0 }
+
+      it "returns epoch time" do
+        expect(at.utc).to eq(Time.utc(1970, 1, 1))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce `Stoplight::Domain::Clock` interface and `Stoplight::Infrastructure::SystemClock` implementation to centralize how Stoplight obtains and interprets time.

- `Domain::Clock`: abstract wall-clock interface defining `#current_time`
  and `#at` methods
- `Infrastructure::SystemClock`: production implementation using Ruby's `Time` class

All time-dependent components should use this interface rather than
calling `Time` methods directly.