### PR TITLE
Extract windowed metrics into per-light storage

### DIFF
--- a/features/stoplight/traffic_control/error_rate.feature
+++ b/features/stoplight/traffic_control/error_rate.feature
@@ -4,7 +4,7 @@ Feature: Error Rate Traffic Control Strategy
   So that my application can respond appropriately to service failures
 
   Background:
-    Given a light "basic-service" configured with:
+    Given a light configured with:
         | Threshold          | 0.4        |
         | Window Size        | 60 seconds |
         | Cool Off Time      | 10 seconds |

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -17,6 +17,8 @@ loader.setup
 module Stoplight # rubocop:disable Style/Documentation
   include Wiring::PublicApi
 
+  T = Types
+
   CONFIG_MUTEX = Mutex.new
   private_constant :CONFIG_MUTEX
   @systems = Concurrent::Map.new

--- a/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
@@ -59,7 +59,7 @@ module Stoplight
               errors = self.errors.sum_in_window(window_start)
               successes = self.successes.sum_in_window(window_start)
 
-              Domain::Metrics.new(
+              Domain::MetricsSnapshot.new(
                 errors: errors,
                 successes: successes,
                 consecutive_errors: [metrics.consecutive_errors, errors].min,

--- a/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
@@ -48,6 +48,7 @@ module Stoplight
             @metrics = DataStore::Memory::Metrics.new
             @successes = DataStore::Memory::SlidingWindow.new(clock:)
             @errors = DataStore::Memory::SlidingWindow.new(clock:)
+            @window_size = T.must(config.window_size)
           end
 
           # Get metrics for the current light
@@ -55,7 +56,7 @@ module Stoplight
           # @return [Stoplight::Domain::Metrics]
           def metrics_snapshot
             mutex.synchronize do
-              window_start = (clock.current_time - config.window_size)
+              window_start = (clock.current_time - @window_size)
               errors = self.errors.sum_in_window(window_start)
               successes = self.successes.sum_in_window(window_start)
 
@@ -78,7 +79,7 @@ module Stoplight
               current_time = clock.current_time
               successes.increment
 
-              if metrics.last_success_at.nil? || current_time > metrics.last_success_at
+              if metrics.last_success_at.nil? || current_time > T.must(metrics.last_success_at)
                 metrics.last_success_at = current_time
               end
 
@@ -97,7 +98,7 @@ module Stoplight
               failure = Domain::Failure.from_error(exception, time: current_time)
               errors.increment
 
-              if metrics.last_error_at.nil? || failure.occurred_at > metrics.last_error_at
+              if metrics.last_error_at.nil? || failure.occurred_at > T.must(metrics.last_error_at)
                 metrics.last_error = failure
               end
 

--- a/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
@@ -4,7 +4,7 @@ module Stoplight
   module Infrastructure
     module Storage
       module Memory
-        # Thread-safe in-memory storage for time-windowed light metrics.
+        # Thread-safe in-memory storage for time-windowed light @
         #
         # This class tracks success and failure counts within a sliding time window,
         # along with consecutive counters and the most recent error. It's designed
@@ -17,22 +17,6 @@ module Stoplight
         # @note All public methods are synchronized via mutex to ensure thread safety.
         #
         class WindowMetrics < Domain::Storage::Metrics
-          # @!attribute metrics
-          #   @return [Stoplight::Infrastructure::DataStore::Memory::Metrics]
-          private attr_accessor :metrics
-
-          # @!attribute successes
-          #   @return [Stoplight::Infrastructure::DataStore::Memory::SlidingWindow]
-          private attr_accessor :successes
-
-          # @!attribute errors
-          #   @return [Stoplight::Infrastructure::DataStore::Memory::SlidingWindow]
-          private attr_accessor :errors
-
-          # @!attribute config
-          #   @return [Stoplight::Domain::Config]
-          private attr_reader :config
-
           # @!attribute mutex
           #   @return [Mutex]
           private attr_reader :mutex
@@ -43,12 +27,10 @@ module Stoplight
 
           def initialize(config:, clock:)
             @clock = clock
-            @config = config
             @mutex = Mutex.new
-            @metrics = DataStore::Memory::Metrics.new
-            @successes = DataStore::Memory::SlidingWindow.new(clock:)
-            @errors = DataStore::Memory::SlidingWindow.new(clock:)
             @window_size = T.must(config.window_size)
+
+            initialize_metrics
           end
 
           # Get metrics for the current light
@@ -57,16 +39,16 @@ module Stoplight
           def metrics_snapshot
             mutex.synchronize do
               window_start = (clock.current_time - @window_size)
-              errors = self.errors.sum_in_window(window_start)
-              successes = self.successes.sum_in_window(window_start)
+              errors = @errors.sum_in_window(window_start)
+              successes = @successes.sum_in_window(window_start)
 
               Domain::MetricsSnapshot.new(
                 errors: errors,
                 successes: successes,
-                consecutive_errors: [metrics.consecutive_errors, errors].min,
-                consecutive_successes: [metrics.consecutive_successes, successes].min,
-                last_error: metrics.last_error,
-                last_success_at: metrics.last_success_at
+                consecutive_errors: [@consecutive_errors, errors].min,
+                consecutive_successes: [@consecutive_successes, successes].min,
+                last_error: @last_error,
+                last_success_at: @last_success_at
               )
             end
           end
@@ -77,14 +59,14 @@ module Stoplight
           def record_success
             mutex.synchronize do
               current_time = clock.current_time
-              successes.increment
+              @successes.increment
 
-              if metrics.last_success_at.nil? || current_time > T.must(metrics.last_success_at)
-                metrics.last_success_at = current_time
+              if @last_success_at.nil? || current_time > T.must(@last_success_at)
+                @last_success_at = current_time
               end
 
-              metrics.consecutive_errors = 0
-              metrics.consecutive_successes += 1
+              @consecutive_errors = 0
+              @consecutive_successes += 1
             end
           end
 
@@ -94,25 +76,33 @@ module Stoplight
           # @return [void]
           def record_failure(exception)
             mutex.synchronize do
-              current_time = clock.current_time
-              failure = Domain::Failure.from_error(exception, time: current_time)
-              errors.increment
+              @errors.increment
 
-              if metrics.last_error_at.nil? || failure.occurred_at > T.must(metrics.last_error_at)
-                metrics.last_error = failure
+              failure = Domain::Failure.from_error(exception, time: clock.current_time)
+              last_error_at = @last_error&.occurred_at
+
+              if last_error_at.nil? || failure.occurred_at > last_error_at
+                @last_error = failure
               end
 
-              metrics.consecutive_errors += 1
-              metrics.consecutive_successes = 0
+              @consecutive_errors += 1
+              @consecutive_successes = 0
             end
           end
 
           def clear
             mutex.synchronize do
-              self.metrics = DataStore::Memory::Metrics.new
-              self.successes = DataStore::Memory::SlidingWindow.new(clock:)
-              self.errors = DataStore::Memory::SlidingWindow.new(clock:)
+              initialize_metrics
             end
+          end
+
+          private def initialize_metrics
+            @consecutive_errors = 0
+            @consecutive_successes = 0
+            @last_error = nil
+            @last_success_at = nil
+            @successes = DataStore::Memory::SlidingWindow.new(clock:)
+            @errors = DataStore::Memory::SlidingWindow.new(clock:)
           end
         end
       end

--- a/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
@@ -4,6 +4,18 @@ module Stoplight
   module Infrastructure
     module Storage
       module Memory
+        # Thread-safe in-memory storage for time-windowed light metrics.
+        #
+        # This class tracks success and failure counts within a sliding time window,
+        # along with consecutive counters and the most recent error. It's designed
+        # for single-process deployments where distributed coordination isn't needed.
+        #
+        # The sliding window approach provides more accurate error rate calculations
+        # than consecutive-error counting, as it considers the full picture of
+        # recent traffic rather than just the most recent streak.
+        #
+        # @note All public methods are synchronized via mutex to ensure thread safety.
+        #
         class WindowMetrics < Domain::Storage::Metrics
           # @!attribute metrics
           #   @return [Stoplight::Infrastructure::DataStore::Memory::Metrics]

--- a/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
@@ -54,9 +54,8 @@ module Stoplight
           #
           # @return [Stoplight::Domain::Metrics]
           def metrics_snapshot
-            window_start = (clock.current_time - config.window_size)
-
             mutex.synchronize do
+              window_start = (clock.current_time - config.window_size)
               errors = self.errors.sum_in_window(window_start)
               successes = self.successes.sum_in_window(window_start)
 
@@ -75,9 +74,8 @@ module Stoplight
           #
           # @return [void]
           def record_success
-            current_time = clock.current_time
-
             mutex.synchronize do
+              current_time = clock.current_time
               successes.increment
 
               if metrics.last_success_at.nil? || current_time > metrics.last_success_at
@@ -94,10 +92,9 @@ module Stoplight
           # @param exception [StandardError]
           # @return [void]
           def record_failure(exception)
-            current_time = clock.current_time
-            failure = Domain::Failure.from_error(exception, time: current_time)
-
             mutex.synchronize do
+              current_time = clock.current_time
+              failure = Domain::Failure.from_error(exception, time: current_time)
               errors.increment
 
               if metrics.last_error_at.nil? || failure.occurred_at > metrics.last_error_at

--- a/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/memory/window_metrics.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Memory
+        class WindowMetrics < Domain::Storage::Metrics
+          # @!attribute metrics
+          #   @return [Stoplight::Infrastructure::DataStore::Memory::Metrics]
+          private attr_accessor :metrics
+
+          # @!attribute successes
+          #   @return [Stoplight::Infrastructure::DataStore::Memory::SlidingWindow]
+          private attr_accessor :successes
+
+          # @!attribute errors
+          #   @return [Stoplight::Infrastructure::DataStore::Memory::SlidingWindow]
+          private attr_accessor :errors
+
+          # @!attribute config
+          #   @return [Stoplight::Domain::Config]
+          private attr_reader :config
+
+          # @!attribute mutex
+          #   @return [Mutex]
+          private attr_reader :mutex
+
+          # @!attribute clock
+          #   @return [Stoplight::Domain::Clock]
+          private attr_reader :clock
+
+          def initialize(config:, clock:)
+            @clock = clock
+            @config = config
+            @mutex = Mutex.new
+            @metrics = DataStore::Memory::Metrics.new
+            @successes = DataStore::Memory::SlidingWindow.new(clock:)
+            @errors = DataStore::Memory::SlidingWindow.new(clock:)
+          end
+
+          # Get metrics for the current light
+          #
+          # @return [Stoplight::Domain::Metrics]
+          def metrics_snapshot
+            window_start = (clock.current_time - config.window_size)
+
+            mutex.synchronize do
+              errors = self.errors.sum_in_window(window_start)
+              successes = self.successes.sum_in_window(window_start)
+
+              Domain::Metrics.new(
+                errors: errors,
+                successes: successes,
+                consecutive_errors: [metrics.consecutive_errors, errors].min,
+                consecutive_successes: [metrics.consecutive_successes, successes].min,
+                last_error: metrics.last_error,
+                last_success_at: metrics.last_success_at
+              )
+            end
+          end
+
+          # Records successful circuit breaker execution
+          #
+          # @return [void]
+          def record_success
+            current_time = clock.current_time
+
+            mutex.synchronize do
+              successes.increment
+
+              if metrics.last_success_at.nil? || current_time > metrics.last_success_at
+                metrics.last_success_at = current_time
+              end
+
+              metrics.consecutive_errors = 0
+              metrics.consecutive_successes += 1
+            end
+          end
+
+          # Records failed circuit breaker execution
+          #
+          # @param exception [StandardError]
+          # @return [void]
+          def record_failure(exception)
+            current_time = clock.current_time
+            failure = Domain::Failure.from_error(exception, time: current_time)
+
+            mutex.synchronize do
+              errors.increment
+
+              if metrics.last_error_at.nil? || failure.occurred_at > metrics.last_error_at
+                metrics.last_error = failure
+              end
+
+              metrics.consecutive_errors += 1
+              metrics.consecutive_successes = 0
+            end
+          end
+
+          def clear
+            mutex.synchronize do
+              self.metrics = DataStore::Memory::Metrics.new
+              self.successes = DataStore::Memory::SlidingWindow.new(clock:)
+              self.errors = DataStore::Memory::SlidingWindow.new(clock:)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Redis
+        class WindowMetrics < Metrics
+          # @!attribute config
+          #   @return [Stoplight::Domain::Config]
+          private attr_reader :config
+
+          # @!attribute redis
+          #   @return [::Redis | ConnectionPool<::Redis>]
+          private attr_reader :redis
+
+          # @!attribute scripting
+          #   @return [Stoplight::Infrastructure::DataStore::Redis::Scripting]
+          private attr_reader :scripting
+
+          # @!attribute metrics_key
+          #   @return [String]
+          private attr_reader :metrics_key
+
+          # @!attribute clock
+          #   @return [Stoplight::Domain::Clock]
+          private attr_reader :clock
+
+          # @!attribute key_space
+          #   @return [Stoplight::Infrastructure::Storage::Redis::KeySpace]
+          private attr_reader :key_space
+
+          def initialize(redis:, scripting:, config:, clock:, key_space:)
+            @clock = clock
+            @scripting = scripting
+            @redis = redis
+            @config = config
+            @key_space = key_space
+            @metrics_key = key_space.key(:window_metrics)
+          end
+
+          # Get metrics for the current light
+          #
+          # @return [Stoplight::Domain::Metrics]
+          def metrics_snapshot
+            window_end_ts = clock.current_time.to_f
+            window_start_ts = window_end_ts - config.window_size
+            failure_keys = failure_bucket_keys(window_end_ts)
+            success_keys = success_bucket_keys(window_end_ts)
+
+            successes, errors, last_success_at, last_error_json, consecutive_errors, consecutive_successes = scripting.call(
+              :"window_metrics/metrics_snapshot",
+              args: [
+                failure_keys.count,
+                window_start_ts,
+                window_end_ts,
+                "last_success_at", "last_error_json", "consecutive_errors", "consecutive_successes"
+              ],
+              keys: [
+                metrics_key,
+                *success_keys,
+                *failure_keys
+              ]
+            )
+            Domain::Metrics.new(
+              successes:, errors:,
+              consecutive_errors: [consecutive_errors.to_i, errors].min,
+              consecutive_successes: [consecutive_successes.to_i, successes].min,
+              last_error: deserialize_failure(last_error_json),
+              last_success_at: (clock.at(last_success_at.to_f) if last_success_at)
+            )
+          end
+
+          # Records successful circuit breaker execution
+          #
+          # @return [void]
+          def record_success
+            timestamp = clock.current_time.to_f
+
+            scripting.call(
+              :"window_metrics/record_success",
+              args: [timestamp, SecureRandom.hex(12), bucket_ttl, metrics_ttl],
+              keys: [
+                metrics_key,
+                successes_key(time: timestamp)
+              ]
+            )
+          end
+
+          # Records failed circuit breaker execution
+          #
+          # @param exception [StandardError]
+          # @return [void]
+          def record_failure(exception)
+            timestamp = clock.current_time.to_f
+
+            scripting.call(
+              :"window_metrics/record_failure",
+              args: [timestamp, SecureRandom.hex(12), serialize_exception(exception, timestamp:), bucket_ttl, metrics_ttl],
+              keys: [metrics_key, errors_key(time: timestamp)]
+            )
+          end
+
+          def clear
+            window_end_ts = clock.current_time.to_f
+            failure_keys = failure_bucket_keys(window_end_ts)
+            success_keys = success_bucket_keys(window_end_ts)
+
+            redis.with do |client|
+              client.del(metrics_key, *failure_keys, *success_keys)
+            end
+          end
+
+          # Generates a Redis key for a specific metric and time.
+          #
+          # @param metric [Symbol] The metric type (e.g., "errors").
+          # @param time [Time, Numeric] The time for which to generate the key.
+          # @return [String] The generated Redis key.
+          def bucket_key(metric:, time:)
+            key_space.key(:window_metrics, metric, (time.to_i / bucket_size) * bucket_size)
+          end
+
+          private def bucket_size = 3600 # 1 hour
+          private def bucket_ttl = bucket_size
+          private def metrics_ttl = 86400 # 1 day
+
+          # Retrieves the list of Redis bucket keys required to cover a specific time window.
+          #
+          # @param metric [Symbol] The metric type (e.g., "errors").
+          # @param window_end [Time, Numeric] The end time of the window (can be a Time object or a numeric timestamp).
+          # @return [Array<String>] A list of Redis keys for the buckets that cover the time window.
+          # @api private
+          def buckets_for_window(metric:, window_end:)
+            window_end_ts = window_end.to_i
+            window_start_ts = window_end_ts - config.window_size.to_i
+
+            # Find bucket timestamps that contain any part of the window
+            start_bucket = (window_start_ts / bucket_size) * bucket_size
+
+            # End bucket is the last bucket that contains data within our window
+            end_bucket = ((window_end_ts - 1) / bucket_size) * bucket_size
+
+            (start_bucket..end_bucket).step(bucket_size).map do |bucket_start|
+              bucket_key(metric: metric, time: bucket_start)
+            end
+          end
+
+          private def successes_key(time:) = bucket_key(metric: :success, time:)
+
+          private def errors_key(time:) = bucket_key(metric: :failure, time:)
+
+          private def failure_bucket_keys(window_end) = buckets_for_window(metric: :failure, window_end:)
+
+          private def success_bucket_keys(window_end) = buckets_for_window(metric: :success, window_end:)
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
@@ -37,10 +37,6 @@ module Stoplight
         # - metrics_snapshot: Aggregates across buckets atomically
         #
         class WindowMetrics < Metrics
-          # @!attribute config
-          #   @return [Stoplight::Domain::Config]
-          private attr_reader :config
-
           # @!attribute redis
           #   @return [::Redis | ConnectionPool<::Redis>]
           private attr_reader :redis
@@ -73,6 +69,7 @@ module Stoplight
             @config = config
             @key_space = key_space
             @metrics_key = key_space.key(:window_metrics)
+            @window_size = T.must(config.window_size)
           end
 
           # Get metrics for the current light
@@ -80,7 +77,7 @@ module Stoplight
           # @return [Stoplight::Domain::Metrics]
           def metrics_snapshot
             window_end_ts = clock.current_time.to_f
-            window_start_ts = window_end_ts - config.window_size
+            window_start_ts = window_end_ts - @window_size
             failure_keys = failure_bucket_keys(window_end_ts)
             success_keys = success_bucket_keys(window_end_ts)
 
@@ -157,7 +154,7 @@ module Stoplight
           end
 
           private def bucket_size = 3600 # 1 hour
-          private def bucket_ttl = config.window_size + bucket_size
+          private def bucket_ttl = @window_size + bucket_size
 
           # Retrieves the list of Redis bucket keys required to cover a specific time window.
           #
@@ -167,7 +164,7 @@ module Stoplight
           # @api private
           def buckets_for_window(metric:, window_end:)
             window_end_ts = window_end.to_i
-            window_start_ts = window_end_ts - config.window_size.to_i
+            window_start_ts = window_end_ts - @window_size
 
             # Find bucket timestamps that contain any part of the window
             start_bucket = (window_start_ts / bucket_size) * bucket_size

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
@@ -4,6 +4,38 @@ module Stoplight
   module Infrastructure
     module Storage
       module Redis
+        # Distributed storage for time-windowed light metrics using Redis.
+        #
+        # This class implements sliding window metrics using Redis sorted sets (ZSETs)
+        # for efficient time-range queries. Events are bucketed by hour to bound memory
+        # usage and enable automatic expiration via Redis TTLs.
+        #
+        # == Storage Structure
+        #
+        # Events are stored in hourly buckets as ZSETs:
+        #   stoplight:{version}:{system}:{light}:window_metrics:success:1696154400
+        #   stoplight:{version}:{system}:{light}:window_metrics:failure:1696154400
+        #
+        # Each ZSET member is a unique event ID with its timestamp as the score,
+        # enabling O(log N) range queries via ZCOUNT.
+        #
+        # Metadata (consecutive counters, last error) is stored in a hash:
+        #   stoplight:{version}:{system}:{light}:window_metrics
+        #
+        # == Bucket Strategy
+        #
+        # Fixed 1-hour buckets provide a balance between:
+        # - Query efficiency: At most ~25 buckets for a 24-hour window
+        # - Memory efficiency: Natural expiration without manual cleanup
+        # - Precision: Sub-bucket accuracy via ZSET scores
+        #
+        # == Atomicity
+        #
+        # All operations use Lua scripts to ensure atomicity:
+        # - record_success: Increments counter and updates metadata in one round-trip
+        # - record_failure: Same, plus stores serialized error details
+        # - metrics_snapshot: Aggregates across buckets atomically
+        #
         class WindowMetrics < Metrics
           # @!attribute config
           #   @return [Stoplight::Domain::Config]
@@ -14,7 +46,7 @@ module Stoplight
           private attr_reader :redis
 
           # @!attribute scripting
-          #   @return [Stoplight::Infrastructure::DataStore::Redis::Scripting]
+          #   @return [Stoplight::Infrastructure::Storage::Redis::Scripting]
           private attr_reader :scripting
 
           # @!attribute metrics_key
@@ -29,6 +61,11 @@ module Stoplight
           #   @return [Stoplight::Infrastructure::Storage::Redis::KeySpace]
           private attr_reader :key_space
 
+          # @param redis [Redis, ConnectionPool<Redis>] Redis client or connection pool
+          # @param scripting [Stoplight::Infrastructure::Storage::Redis::Scripting] Lua script executor
+          # @param config [Stoplight::Domain::Config]
+          # @param clock [Stoplight::Domain::Clock]
+          # @param key_space [Stoplight::Infrastructure::Storage::Redis::KeySpace]
           def initialize(redis:, scripting:, config:, clock:, key_space:)
             @clock = clock
             @scripting = scripting
@@ -120,8 +157,7 @@ module Stoplight
           end
 
           private def bucket_size = 3600 # 1 hour
-          private def bucket_ttl = bucket_size
-          private def metrics_ttl = 86400 # 1 day
+          private def bucket_ttl = config.window_size + bucket_size
 
           # Retrieves the list of Redis bucket keys required to cover a specific time window.
           #

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
@@ -98,7 +98,7 @@ module Stoplight
                 *failure_keys
               ]
             )
-            Domain::Metrics.new(
+            Domain::MetricsSnapshot.new(
               successes:, errors:,
               consecutive_errors: [consecutive_errors.to_i, errors].min,
               consecutive_successes: [consecutive_successes.to_i, successes].min,

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics.rb
@@ -69,7 +69,7 @@ module Stoplight
             @config = config
             @key_space = key_space
             @metrics_key = key_space.key(:window_metrics)
-            @window_size = T.must(config.window_size)
+            @window_size = T.must(config.window_size).to_i
           end
 
           # Get metrics for the current light

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics/metrics_snapshot.lua
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics/metrics_snapshot.lua
@@ -1,0 +1,26 @@
+local number_of_metric_buckets = tonumber(ARGV[1])
+local window_start_ts = tonumber(ARGV[2])
+local window_end_ts = tonumber(ARGV[3])
+local metrics_keys = {}
+for idx = 4, #ARGV do
+  table.insert(metrics_keys, ARGV[idx])
+end
+
+local metadata_key = KEYS[1]
+
+local function count_events(start_idx, bucket_count, start_ts)
+  local total = 0
+  for idx = start_idx, start_idx + bucket_count - 1 do
+    total = total + tonumber(redis.call('ZCOUNT', KEYS[idx], start_ts, window_end_ts))
+  end
+  return total
+end
+
+local offset = 2
+local successes = count_events(2, number_of_metric_buckets, window_start_ts)
+
+offset = offset + number_of_metric_buckets
+local errors = count_events(offset, number_of_metric_buckets, window_start_ts)
+
+local metrics = redis.call('HMGET',  metadata_key, unpack(metrics_keys))
+return {successes, errors, unpack(metrics)}

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics/metrics_snapshot.lua
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics/metrics_snapshot.lua
@@ -1,12 +1,12 @@
 local number_of_metric_buckets = tonumber(ARGV[1])
 local window_start_ts = tonumber(ARGV[2])
 local window_end_ts = tonumber(ARGV[3])
-local metrics_keys = {}
+local metrics_fields = {}
 for idx = 4, #ARGV do
-  table.insert(metrics_keys, ARGV[idx])
+  table.insert(metrics_fields, ARGV[idx])
 end
 
-local metadata_key = KEYS[1]
+local metrics_key = KEYS[1]
 
 local function count_events(start_idx, bucket_count, start_ts)
   local total = 0
@@ -22,5 +22,5 @@ local successes = count_events(2, number_of_metric_buckets, window_start_ts)
 offset = offset + number_of_metric_buckets
 local errors = count_events(offset, number_of_metric_buckets, window_start_ts)
 
-local metrics = redis.call('HMGET',  metadata_key, unpack(metrics_keys))
+local metrics = redis.call('HMGET',  metrics_key, unpack(metrics_fields))
 return {successes, errors, unpack(metrics)}

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics/record_failure.lua
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics/record_failure.lua
@@ -1,0 +1,36 @@
+local failure_ts = tonumber(ARGV[1])
+local failure_id = ARGV[2]
+local failure_json = ARGV[3]
+local bucket_ttl = tonumber(ARGV[4])
+local metadata_ttl = tonumber(ARGV[5])
+
+local metadata_key = KEYS[1]
+local errors_key = KEYS[2]
+
+-- Record failure
+if errors_key ~= nil then
+  redis.call('ZADD', errors_key, failure_ts, failure_id)
+  redis.call('EXPIRE', errors_key, bucket_ttl) -- Not supported in Redis 6.2:, 'NX')
+end
+
+-- Update metadata
+local meta = redis.call('HMGET', metadata_key, 'last_error_at', 'consecutive_errors')
+local prev_failure_ts = tonumber(meta[1])
+local prev_consecutive_errors = tonumber(meta[2])
+
+if not prev_failure_ts or failure_ts > prev_failure_ts then
+  redis.call(
+    'HSET', metadata_key,
+    'last_error_at', failure_ts,
+    'last_error_json', failure_json,
+    'consecutive_errors', (prev_consecutive_errors or 0) + 1,
+    'consecutive_successes', 0
+  )
+else
+  redis.call(
+    'HSET', metadata_key,
+    'consecutive_errors', (prev_consecutive_errors or 0) + 1,
+    'consecutive_successes', 0
+  )
+end
+redis.call('EXPIRE', metadata_key, metadata_ttl) -- Not supported in Redis 6.2:, 'GT')

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics/record_failure.lua
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics/record_failure.lua
@@ -4,23 +4,23 @@ local failure_json = ARGV[3]
 local bucket_ttl = tonumber(ARGV[4])
 local metadata_ttl = tonumber(ARGV[5])
 
-local metadata_key = KEYS[1]
-local errors_key = KEYS[2]
+local metrics_key = KEYS[1]
+local failures_key = KEYS[2]
 
 -- Record failure
-if errors_key ~= nil then
-  redis.call('ZADD', errors_key, failure_ts, failure_id)
-  redis.call('EXPIRE', errors_key, bucket_ttl) -- Not supported in Redis 6.2:, 'NX')
+if failures_key ~= nil then
+  redis.call('ZADD', failures_key, failure_ts, failure_id)
+  redis.call('EXPIRE', failures_key, bucket_ttl) -- Not supported in Redis 6.2:, 'NX')
 end
 
 -- Update metadata
-local meta = redis.call('HMGET', metadata_key, 'last_error_at', 'consecutive_errors')
+local meta = redis.call('HMGET', metrics_key, 'last_error_at', 'consecutive_errors')
 local prev_failure_ts = tonumber(meta[1])
 local prev_consecutive_errors = tonumber(meta[2])
 
 if not prev_failure_ts or failure_ts > prev_failure_ts then
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'last_error_at', failure_ts,
     'last_error_json', failure_json,
     'consecutive_errors', (prev_consecutive_errors or 0) + 1,
@@ -28,9 +28,9 @@ if not prev_failure_ts or failure_ts > prev_failure_ts then
   )
 else
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'consecutive_errors', (prev_consecutive_errors or 0) + 1,
     'consecutive_successes', 0
   )
 end
-redis.call('EXPIRE', metadata_key, metadata_ttl) -- Not supported in Redis 6.2:, 'GT')
+redis.call('EXPIRE', metrics_key, metadata_ttl) -- Not supported in Redis 6.2:, 'GT')

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics/record_success.lua
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics/record_success.lua
@@ -1,0 +1,35 @@
+local request_ts = tonumber(ARGV[1])
+local request_id = ARGV[2]
+local bucket_ttl = tonumber(ARGV[3])
+local metadata_ttl = tonumber(ARGV[4])
+
+local metadata_key = KEYS[1]
+local successes_key = KEYS[2]
+
+-- Record success
+if successes_key ~= nil then
+  redis.call('ZADD', successes_key, request_ts, request_id)
+  redis.call('EXPIRE', successes_key, bucket_ttl) -- Not supported in Redis 6.2:, 'NX')
+end
+
+-- Update metadata
+local meta = redis.call('HMGET', metadata_key, 'last_success_at', 'consecutive_successes')
+local prev_success_ts = tonumber(meta[1])
+local prev_consecutive_successes = tonumber(meta[2])
+
+if not prev_success_ts or request_ts > prev_success_ts then
+  redis.call(
+    'HSET', metadata_key,
+    'last_success_at', request_ts,
+    'consecutive_errors', 0,
+    'consecutive_successes', (prev_consecutive_successes or 0) + 1
+  )
+else
+  redis.call(
+    'HSET', metadata_key,
+    'consecutive_errors', 0,
+    'consecutive_successes', (prev_consecutive_successes or 0) + 1
+  )
+end
+
+redis.call('EXPIRE', metadata_key, metadata_ttl) -- Not supported in Redis 6.2:, 'GT')

--- a/lib/stoplight/infrastructure/storage/redis/window_metrics/record_success.lua
+++ b/lib/stoplight/infrastructure/storage/redis/window_metrics/record_success.lua
@@ -3,7 +3,7 @@ local request_id = ARGV[2]
 local bucket_ttl = tonumber(ARGV[3])
 local metadata_ttl = tonumber(ARGV[4])
 
-local metadata_key = KEYS[1]
+local metrics_key = KEYS[1]
 local successes_key = KEYS[2]
 
 -- Record success
@@ -13,23 +13,23 @@ if successes_key ~= nil then
 end
 
 -- Update metadata
-local meta = redis.call('HMGET', metadata_key, 'last_success_at', 'consecutive_successes')
+local meta = redis.call('HMGET', metrics_key, 'last_success_at', 'consecutive_successes')
 local prev_success_ts = tonumber(meta[1])
 local prev_consecutive_successes = tonumber(meta[2])
 
 if not prev_success_ts or request_ts > prev_success_ts then
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'last_success_at', request_ts,
     'consecutive_errors', 0,
     'consecutive_successes', (prev_consecutive_successes or 0) + 1
   )
 else
   redis.call(
-    'HSET', metadata_key,
+    'HSET', metrics_key,
     'consecutive_errors', 0,
     'consecutive_successes', (prev_consecutive_successes or 0) + 1
   )
 end
 
-redis.call('EXPIRE', metadata_key, metadata_ttl) -- Not supported in Redis 6.2:, 'GT')
+redis.call('EXPIRE', metrics_key, metadata_ttl) -- Not supported in Redis 6.2:, 'GT')

--- a/lib/stoplight/types.rb
+++ b/lib/stoplight/types.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Types
+    # Asserts a value is non-nil, returning it with a narrowed type.
+    #
+    # Use this to satisfy Steep's flow typing when you know a nilable value
+    # must be present. Prefer this over type assertions (#: Type) since it
+    # provides runtime validation.
+    #
+    # @example Validating required configuration
+    #   @window_size = T.must(config.window_size)
+    #
+    # @raise [ArgumentError] if value is nil
+    # @return [T] the non-nil value
+    #
+    def self.must(value)
+      if value.nil?
+        raise ArgumentError, "must not have nil value"
+      else
+        value
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/system/light_builder.rb
+++ b/lib/stoplight/wiring/system/light_builder.rb
@@ -70,7 +70,18 @@ module Stoplight
 
         private def redis_metrics_store
           if config.window_size
-            Infrastructure::Storage::CompatibilityMetrics.new(config:, data_store:)
+            Infrastructure::Storage::FailSafe::Metrics.new(
+              error_notifier:,
+              primary_store: Infrastructure::Storage::Redis::WindowMetrics.new(
+                config:,
+                redis:,
+                scripting: storage_scripting,
+                clock:,
+                key_space:
+              ),
+              failover_store: Infrastructure::Storage::Memory::WindowMetrics.new(config:, clock:),
+              circuit_breaker: failover_system.light("redis")
+            )
           else
             Infrastructure::Storage::FailSafe::Metrics.new(
               error_notifier:,
@@ -88,7 +99,7 @@ module Stoplight
 
         private def memory_metrics_store
           if config.window_size
-            Infrastructure::Storage::CompatibilityMetrics.new(config:, data_store:)
+            Infrastructure::Storage::Memory::WindowMetrics.new(config:, clock:)
           else
             Infrastructure::Storage::Memory::UnboundedMetrics.new(clock:)
           end

--- a/sig/stoplight.rbs
+++ b/sig/stoplight.rbs
@@ -1,4 +1,5 @@
 module Stoplight
+  T: singleton(Types)
   type timestamp = Float | Integer
   type redis = ::Redis | ConnectionPool[::Redis]
 

--- a/sig/stoplight/infrastructure/storage/memory/window_metrics.rbs
+++ b/sig/stoplight/infrastructure/storage/memory/window_metrics.rbs
@@ -3,17 +3,20 @@ module Stoplight
     module Storage
       module Memory
         class WindowMetrics < Domain::Storage::Metrics
-          attr_accessor metrics: DataStore::Memory::Metrics
-          attr_accessor successes: DataStore::Memory::SlidingWindow
-          attr_accessor errors: DataStore::Memory::SlidingWindow
-          attr_reader config: Domain::Config
           attr_reader mutex: Mutex
           attr_reader clock: Domain::Clock
+
           @window_size: Integer
+          @consecutive_errors: Integer
+          @consecutive_successes: Integer
+          @last_error: Domain::Failure?
+          @last_success_at: Time?
+          @successes: DataStore::Memory::SlidingWindow
+          @errors: DataStore::Memory::SlidingWindow
 
           def initialize: (config: Domain::Config, clock: Domain::Clock) -> void
 
-
+          def initialize_metrics: -> void
         end
       end
     end

--- a/sig/stoplight/infrastructure/storage/memory/window_metrics.rbs
+++ b/sig/stoplight/infrastructure/storage/memory/window_metrics.rbs
@@ -1,0 +1,21 @@
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Memory
+        class WindowMetrics < Domain::Storage::Metrics
+          attr_accessor metrics: DataStore::Memory::Metrics
+          attr_accessor successes: DataStore::Memory::SlidingWindow
+          attr_accessor errors: DataStore::Memory::SlidingWindow
+          attr_reader config: Domain::Config
+          attr_reader mutex: Mutex
+          attr_reader clock: Domain::Clock
+          @window_size: Integer
+
+          def initialize: (config: Domain::Config, clock: Domain::Clock) -> void
+
+
+        end
+      end
+    end
+  end
+end

--- a/sig/stoplight/infrastructure/storage/redis/window_metrics.rbs
+++ b/sig/stoplight/infrastructure/storage/redis/window_metrics.rbs
@@ -1,0 +1,34 @@
+module Stoplight
+  module Infrastructure
+    module Storage
+      module Redis
+        class WindowMetrics < Metrics
+          attr_reader config: Domain::Config
+          attr_reader redis: redis
+          attr_reader scripting: Scripting
+          attr_reader metrics_key: String
+          attr_reader clock: Domain::Clock
+          attr_reader key_space: KeySpace
+          @window_size: Integer
+
+          def initialize: (
+            redis: redis,
+            scripting: Scripting,
+            config: Domain::Config,
+            clock: Domain::Clock,
+            key_space: KeySpace
+          ) -> void
+
+          def bucket_key: (metric: Symbol, time: _ToI) -> String
+          def bucket_size: -> Integer
+          def bucket_ttl: -> Integer
+          def buckets_for_window: (metric: Symbol, window_end: _ToI) -> Array[String]
+          def successes_key: (time: _ToI) -> String
+          def errors_key: (time: _ToI) -> String
+          def failure_bucket_keys: (_ToI window_end) -> Array[String]
+          def success_bucket_keys: (_ToI window_end) -> Array[String]
+        end
+      end
+    end
+  end
+end

--- a/sig/stoplight/types.rbs
+++ b/sig/stoplight/types.rbs
@@ -1,0 +1,5 @@
+module Stoplight
+  module Types
+    def self.must: [T < Object] (T? value) -> T
+  end
+end

--- a/spec/unit/stoplight/infrastructure/storage/memory/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/memory/window_metrics_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../../data_store/window_metrics_snapshot"
+
+RSpec.describe Stoplight::Infrastructure::Storage::Memory::WindowMetrics do
+  subject(:metrics) { described_class.new(config:, clock:) }
+
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
+  let(:config) { instance_double(Stoplight::Domain::Config, window_size:) }
+  let(:window_size) { 300 }
+
+  it_behaves_like "a window metrics snapshot" do
+    def metrics_snapshot = metrics.metrics_snapshot
+    def record_failure(error) = metrics.record_failure(error)
+    def record_success = metrics.record_success
+  end
+end

--- a/spec/unit/stoplight/infrastructure/storage/redis/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/storage/redis/window_metrics_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "../../data_store/window_metrics_snapshot"
+
+RSpec.describe Stoplight::Infrastructure::Storage::Redis::WindowMetrics, :redis do
+  subject(:metrics) { described_class.new(scripting:, redis:, config:, clock:, key_space:) }
+
+  let(:key_space) { Stoplight::Infrastructure::Storage::Redis::KeySpace.build(light_name:, system_name:) }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
+  let(:config) { instance_double(Stoplight::Domain::Config, window_size:) }
+  let(:scripting) { Stoplight::Infrastructure::Storage::Redis::Scripting.new(redis:) }
+  let(:window_size) { 300 }
+
+  let(:light_name) { SecureRandom.uuid }
+  let(:system_name) { SecureRandom.uuid }
+
+  it_behaves_like "a window metrics snapshot" do
+    def metrics_snapshot = metrics.metrics_snapshot
+    def record_failure(error) = metrics.record_failure(error)
+    def record_success = metrics.record_success
+  end
+
+  describe "#buckets_for_window" do
+    subject(:buckets) { metrics.buckets_for_window(metric:, window_end:) }
+
+    let(:metric) { "failures" }
+
+    context "when window size is smaller than the bucket size" do
+      let(:window_end) { Time.at(1696156496) }
+      let(:window_size) { 1000 } # Smaller than BUCKET_SIZE (3600)
+
+      it "returns a single bucket key" do
+        is_expected.to contain_exactly(
+          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696154400"
+        )
+      end
+    end
+
+    context "when window size spans multiple buckets" do
+      let(:window_end) { Time.at(1696154400) }
+      let(:window_size) { 14400 } # Spans 4 buckets (3600s each)
+
+      it "returns all bucket keys within the window" do
+        is_expected.to contain_exactly(
+          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696140000",
+          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696143600",
+          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696147200",
+          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696150800"
+        )
+      end
+    end
+
+    context "when window size is exactly one bucket size" do
+      let(:window_end) { Time.at(1696154400) }
+      let(:window_size) { 3600 } # Exactly one bucket size
+
+      it "returns the single bucket key" do
+        is_expected.to contain_exactly(
+          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696150800"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracts metrics tracking from DataStore into dedicated per-circuit storage instances, continuing the storage abstraction separation.

This PR applies the same pattern we used for recovery locks and state to metrics, specifically for circuits **with** `window_size` (windowed metrics tracking).

**Before:** DataStore handled metrics for ALL circuits

```ruby
data_store.record_success(config)
data_store.record_failure(config, error)
```

**After:** Each circuit has its own metrics storage instance

```ruby
metrics_store = Redis::WindowedMetrics.new(redis:, scripting:, key_space:, clock:)
metrics_store.record_success        # No config needed - knows its circuit
metrics_store.record_failure(error)
```

Circuits without `window_size` still use `CompatibilityMetrics` adapter until unbounded metrics storage is implemented.