### PR TITLE
Support cluster mode

### DIFF
--- a/lib/stoplight/infrastructure/redis/storage/key_space.rb
+++ b/lib/stoplight/infrastructure/redis/storage/key_space.rb
@@ -43,7 +43,7 @@ module Stoplight
           #
           # @param pieces  Key segments to append
           # @return  Full Redis key
-          def key(*pieces) = [:stoplight, :v6, system_id, light_id, *pieces].join(":")
+          def key(*pieces) = [:stoplight, :v6, system_id, "{#{light_id}}", *pieces].join(":")
         end
       end
     end

--- a/spec/unit/stoplight/infrastructure/redis/storage/key_space_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/key_space_spec.rb
@@ -24,19 +24,19 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::KeySpace do
     context "with a pattern" do
       let(:pieces) { ["*"] }
 
-      it { is_expected.to eq("stoplight:v6:system:light:*") }
+      it { is_expected.to eq("stoplight:v6:system:{light}:*") }
     end
 
     context "with one piece" do
       let(:pieces) { ["metadata"] }
 
-      it { is_expected.to eq("stoplight:v6:system:light:metadata") }
+      it { is_expected.to eq("stoplight:v6:system:{light}:metadata") }
     end
 
     context "with multiple pieces" do
       let(:pieces) { ["this", "that"] }
 
-      it { is_expected.to eq("stoplight:v6:system:light:this:that") }
+      it { is_expected.to eq("stoplight:v6:system:{light}:this:that") }
     end
   end
 end

--- a/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::WindowMetrics, :redis 
 
       it "returns a single bucket key" do
         is_expected.to contain_exactly(
-          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696154400"
+          "stoplight:v6:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696154400"
         )
       end
     end
@@ -42,10 +42,10 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::WindowMetrics, :redis 
 
       it "returns all bucket keys within the window" do
         is_expected.to contain_exactly(
-          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696140000",
-          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696143600",
-          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696147200",
-          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696150800"
+          "stoplight:v6:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696140000",
+          "stoplight:v6:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696143600",
+          "stoplight:v6:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696147200",
+          "stoplight:v6:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696150800"
         )
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::WindowMetrics, :redis 
 
       it "returns the single bucket key" do
         is_expected.to contain_exactly(
-          "stoplight:v6:#{key_space.system_id}:#{key_space.light_id}:window_metrics:failures:1696150800"
+          "stoplight:v6:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696150800"
         )
       end
     end


### PR DESCRIPTION
First step for the cluster mode support. Keys are clustered by light id.