### PR TITLE
Use UTC time

### DIFF
--- a/lib/stoplight/admin/helpers.rb
+++ b/lib/stoplight/admin/helpers.rb
@@ -14,6 +14,21 @@ module Stoplight
         Dependencies.new(data_store:)
       end
 
+      def time_ago_in_words(time)
+        time_difference = Time.now.utc - time
+        if time_difference < 1
+          "just now"
+        elsif time_difference < 60
+          "#{time_difference.to_i}s ago"
+        elsif time_difference < 3600
+          "#{(time_difference / 60).to_i}m ago"
+        elsif time_difference < 86400
+          "#{(time_difference / 3600).to_i}h ago"
+        else
+          "#{(time_difference / 86400).to_i}d ago"
+        end
+      end
+
       private def data_store
         if settings.data_store.is_a?(Stoplight::DataStore::Memory)
           raise "Stoplight Admin requires a persistent data store, but the current data store is Memory. " \

--- a/lib/stoplight/admin/lights_repository/light.rb
+++ b/lib/stoplight/admin/lights_repository/light.rb
@@ -85,20 +85,24 @@ module Stoplight
           [-COLORS.index(color), name]
         end
 
+        def last_check = latest_failure&.time # TODO: take into account positive checks as well
+
         # @return [String, nil]
         def last_check_in_words
           last_error_time = latest_failure&.time
           return unless last_error_time
 
-          time_difference = Time.now - last_error_time
+          time_difference = Time.now.utc - last_error_time
           if time_difference < 1
             "just now"
           elsif time_difference < 60
             "#{time_difference.to_i}s ago"
           elsif time_difference < 3600
             "#{(time_difference / 60).to_i}m ago"
-          else
+          elsif time_difference < 86400
             "#{(time_difference / 3600).to_i}h ago"
+          else
+            "#{(time_difference / 86400).to_i}d ago"
           end
         end
 

--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -107,8 +107,11 @@
         <p><%= light.description_comment %></p>
       </div>
       <% if light.latest_failure %>
-        <div class="whitespace-nowrap">
-          <%= Time.at(light.latest_failure.time).strftime("%T") %>
+        <div class="whitespace-nowrap text-center">
+          <%= light.latest_failure.time.strftime("%F %T") %>
+          <span class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">
+            UTC
+          </span>
         </div>
       <% end %>
     </div>
@@ -120,10 +123,10 @@
       <span class="font-medium">Failures:</span> <%= light.failure_count %>
     </div>
 
-    <% light.last_check_in_words.then do |last_check| %>
+    <% light.last_check.then do |last_check| %>
       <% if last_check %>
         <div>
-          <span class="font-medium">Last Check:</span> <%= light.last_check_in_words %>
+          <span class="font-medium">Last Check:</span><%= time_ago_in_words(last_check) %>
         </div>
       <% end %>
     <% end %>

--- a/lib/stoplight/infrastructure/redis/data_store.rb
+++ b/lib/stoplight/infrastructure/redis/data_store.rb
@@ -75,7 +75,7 @@ module Stoplight
         end
 
         KEY_SEPARATOR = ":"
-        KEY_PREFIX = %w[stoplight v5].join(KEY_SEPARATOR)
+        KEY_PREFIX = %w[stoplight v6].join(KEY_SEPARATOR)
 
         # @!attribute recovery_lock_store
         #   @return [Stoplight::Infrastructure::Redis::DataStore::RecoveryLockStore]

--- a/lib/stoplight/infrastructure/system_clock.rb
+++ b/lib/stoplight/infrastructure/system_clock.rb
@@ -8,9 +8,9 @@ module Stoplight
     # bucket calculation, window boundaries, and state transition timestamps.
     #
     class SystemClock
-      def current_time = Time.now
+      def current_time = Time.now.utc
 
-      def at(timestamp) = Time.at(timestamp)
+      def at(timestamp) = Time.at(timestamp).utc
     end
   end
 end

--- a/spec/unit/stoplight/infrastructure/redis/data_store_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/data_store_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::DataStore, :redis do
 
       it "returns a single bucket key" do
         is_expected.to contain_exactly(
-          "stoplight:v5:metrics:test-light:failures:1696154400"
+          "stoplight:v6:metrics:test-light:failures:1696154400"
         )
       end
     end
@@ -36,10 +36,10 @@ RSpec.describe Stoplight::Infrastructure::Redis::DataStore, :redis do
 
       it "returns all bucket keys within the window" do
         is_expected.to contain_exactly(
-          "stoplight:v5:metrics:test-light:failures:1696140000",
-          "stoplight:v5:metrics:test-light:failures:1696143600",
-          "stoplight:v5:metrics:test-light:failures:1696147200",
-          "stoplight:v5:metrics:test-light:failures:1696150800"
+          "stoplight:v6:metrics:test-light:failures:1696140000",
+          "stoplight:v6:metrics:test-light:failures:1696143600",
+          "stoplight:v6:metrics:test-light:failures:1696147200",
+          "stoplight:v6:metrics:test-light:failures:1696150800"
         )
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::DataStore, :redis do
 
       it "returns the single bucket key" do
         is_expected.to contain_exactly(
-          "stoplight:v5:metrics:test-light:failures:1696150800"
+          "stoplight:v6:metrics:test-light:failures:1696150800"
         )
       end
     end


### PR DESCRIPTION
Closes #473 
Replaces #487

Stoplight currently uses local time for Redis key generation and time bucketing. This causes issues during daylight saving time transitions:

- When clocks fall back 1 hour, Stoplight reads statistics from the previous hour, causing incorrect error rate calculations and potentially inappropriate circuit breaker state changes
- When clocks spring forward 1 houh, there's a gap in statistics, which may cause circuits to incorrectly open due to missing data
- Services deployed in different timezones may have inconsistent behavior

This PR changes time handling to always use UTC time. UI now clearly states that the time shouwn is in UTC timezone:

<img width="628" height="278" alt="Screenshot 2026-02-06 at 18 16 09" src="https://github.com/user-attachments/assets/78abe855-8649-4b09-b1b6-0d38f4091995" />


🚨 This is a backward incompatible change as it affects redis keys generation